### PR TITLE
feat!: Better reproducibility management of dynamic problems with `SeededEnvironment`

### DIFF
--- a/docs/src/custom_benchmarks.md
+++ b/docs/src/custom_benchmarks.md
@@ -121,25 +121,38 @@ Dynamic benchmarks extend stochastic ones with an environment-based rollout inte
 ### Environment generation
 
 ```julia
-# Strategy A: generate one environment at a time (default implementation of
-#              generate_environments calls this repeatedly)
-generate_environment(bench::MyDynamicBenchmark, rng::AbstractRNG; kwargs...) -> AbstractEnvironment
+# Option A: build one bare environment (the framework wraps it in a SeededEnvironment)
+build_environment(bench::MyDynamicBenchmark, rng::AbstractRNG; kwargs...) -> AbstractEnvironment
 
-# Strategy B: override when environments are not independent (e.g. loaded from files)
-generate_environments(bench::MyDynamicBenchmark, n::Int; rng, kwargs...) -> Vector{<:AbstractEnvironment}
+# Option B: override when environments are not independent (e.g. loaded from files)
+generate_environments(bench::MyDynamicBenchmark, n::Int; seed=nothing, kwargs...) -> Vector{SeededEnvironment}
 ```
+
+You implement **`build_environment`**, which returns a *bare* environment. The package then automatically wraps it in a [`SeededEnvironment`](@ref) (attaching a seed and RNG) through two public entry points:
+
+```julia
+generate_environment(bench; seed=nothing, kwargs...)      -> SeededEnvironment       # one env
+generate_environments(bench, n; seed=nothing, kwargs...)  -> Vector{SeededEnvironment} # n envs
+```
+
+For environments that cannot be drawn independently (e.g. loaded from files), override `generate_environments` instead of implementing `build_environment`.
+An override must return already-wrapped `SeededEnvironment`s (use `SeededEnvironment(env; seed=...)`).
+Do not override `generate_environment`: it just delegates to `generate_environments`.
 
 ### `AbstractEnvironment` interface
 
-Your environment type must implement:
+Your environment must be **stateless about randomness**: it does *not* store its own RNG or seed.
+All randomness is owned by the wrapping [`SeededEnvironment`](@ref), which passes its `rng` into every `reset!` and `step!`.
+Draw all stochasticity from that `rng` so that re-seeding the wrapper (via [`reset_to_initial!`](@ref)) replays an episode exactly.
 
 ```julia
-get_seed(env::MyEnv)                             # Return the RNG seed used at creation
-reset!(env::MyEnv; reset_rng::Bool, seed=get_seed(env))  # Reset to initial state
-observe(env::MyEnv) -> (observation, info)       # Current observation
-step!(env::MyEnv, action) -> reward              # Apply action, advance state
-is_terminated(env::MyEnv) -> Bool                # True when episode has ended
+reset!(env::MyEnv, rng::AbstractRNG)                    # Reset to a starting state, sampling from rng
+observe(env::MyEnv) -> (observation, state)             # Current observation and internal state
+step!(env::MyEnv, action, rng::AbstractRNG) -> reward   # Apply action, advance state (draw from rng)
+is_terminated(env::MyEnv) -> Bool                       # True when the episode has ended
 ```
+
+Environments may ignore the `rng` argument.
 
 ### Baseline policies (required for `generate_dataset`)
 

--- a/docs/src/using_benchmarks.md
+++ b/docs/src/using_benchmarks.md
@@ -133,11 +133,11 @@ rollout and returns the resulting trajectory.
 ## Seed / RNG control
 
 All `generate_dataset` and `generate_environments` calls accept either `seed`
-(creates an internal `MersenneTwister`) or `rng` for full control:
+(creates an internal `Xoshiro`) or `rng` for full control:
 
 ```julia
 using Random
-rng = MersenneTwister(42)
+rng = Xoshiro(42)
 dataset = generate_dataset(bench, 50; rng=rng)
 ```
 

--- a/docs/src/using_benchmarks.md
+++ b/docs/src/using_benchmarks.md
@@ -132,14 +132,24 @@ rollout and returns the resulting trajectory.
 
 ## Seed / RNG control
 
-All `generate_dataset` and `generate_environments` calls accept either `seed`
-(creates an internal `Xoshiro`) or `rng` for full control:
+`generate_dataset` accepts either `seed` (creates an internal `Xoshiro`) or `rng` (any `AbstractRNG`)::
 
 ```julia
 using Random
 rng = Xoshiro(42)
 dataset = generate_dataset(bench, 50; rng=rng)
 ```
+
+`generate_environments` takes a `seed`:
+
+```julia
+envs = generate_environments(bench, 10; seed=0)
+```
+
+### Reproducibility in dynamic benchmarks
+
+Each environment returned by `generate_environments` or `generate_environment` is a `SeededEnvironment`: a wrapper that owns the random number generator and a stored seed.
+It is the single source of randomness for the episode, so re-running a policy on the same environment replays the exact same trajectory. `evaluate_policy!` resets to the stored seed before each run, which is what makes evaluation reproducible (pass `seed=...` to override the stored seed for a given run).
 
 ---
 

--- a/src/Argmax2D/Argmax2D.jl
+++ b/src/Argmax2D/Argmax2D.jl
@@ -4,7 +4,7 @@ using ..Utils
 using DocStringExtensions: TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES
 using Flux: Chain, Dense
 using LinearAlgebra: dot, norm
-using Random: Random, MersenneTwister, AbstractRNG
+using Random: Random, Xoshiro, AbstractRNG
 
 include("polytope.jl")
 
@@ -79,7 +79,7 @@ $TYPEDSIGNATURES
 Generate a statistical model for the [`Argmax2DBenchmark`](@ref).
 """
 function Utils.generate_statistical_model(
-    bench::Argmax2DBenchmark; seed=nothing, rng=MersenneTwister(seed)
+    bench::Argmax2DBenchmark; seed=nothing, rng=Xoshiro(seed)
 )
     Random.seed!(rng, seed)
     (; nb_features) = bench

--- a/src/ContextualStochasticArgmax/ContextualStochasticArgmax.jl
+++ b/src/ContextualStochasticArgmax/ContextualStochasticArgmax.jl
@@ -4,7 +4,7 @@ using ..Utils
 using DocStringExtensions: TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES
 using Flux: Dense
 using LinearAlgebra: dot
-using Random: Random, AbstractRNG, MersenneTwister
+using Random: Random, AbstractRNG, Xoshiro
 using Statistics: mean
 
 """
@@ -37,7 +37,7 @@ end
 function ContextualStochasticArgmaxBenchmark(;
     n::Int=10, d::Int=5, noise_std::Float32=0.1f0, seed=nothing
 )
-    rng = MersenneTwister(seed)
+    rng = Xoshiro(seed)
     W = randn(rng, Float32, n, d)
     return ContextualStochasticArgmaxBenchmark(n, d, W, noise_std)
 end

--- a/src/DecisionFocusedLearningBenchmarks.jl
+++ b/src/DecisionFocusedLearningBenchmarks.jl
@@ -72,7 +72,11 @@ export get_seed, is_terminated, observe, reset!, reset_to_initial!, step!
 export Policy, evaluate_policy!
 
 export generate_instance,
-    generate_sample, generate_dataset, generate_environments, generate_environment
+    generate_sample,
+    generate_dataset,
+    build_environment,
+    generate_environment,
+    generate_environments
 export generate_scenario, generate_context
 export generate_baseline_policies
 export SampleAverageApproximation

--- a/src/DecisionFocusedLearningBenchmarks.jl
+++ b/src/DecisionFocusedLearningBenchmarks.jl
@@ -66,7 +66,8 @@ using .Utils
 export AbstractBenchmark, AbstractStochasticBenchmark, AbstractDynamicBenchmark, DataSample
 export ExogenousStochasticBenchmark,
     EndogenousStochasticBenchmark, ExogenousDynamicBenchmark, EndogenousDynamicBenchmark
-export AbstractEnvironment, get_seed, is_terminated, observe, reset!, step!
+export AbstractEnvironment, SeededEnvironment
+export get_seed, is_terminated, observe, reset!, reset_to_initial!, step!
 
 export Policy, evaluate_policy!
 

--- a/src/DynamicAssortment/DynamicAssortment.jl
+++ b/src/DynamicAssortment/DynamicAssortment.jl
@@ -6,7 +6,7 @@ using DocStringExtensions: TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES, SIGNATURES
 using Distributions: Uniform, Categorical
 using Flux: Chain, Dense
 using LinearAlgebra: dot
-using Random: Random, AbstractRNG, MersenneTwister
+using Random: Random, AbstractRNG, Xoshiro
 using Statistics: mean
 
 using Combinatorics: combinations
@@ -100,14 +100,13 @@ end
 $TYPEDSIGNATURES
 
 Creates an [`Environment`](@ref) for the dynamic assortment benchmark.
-The instance and seed are randomly generated using the provided random number generator.
+The instance is randomly generated using the provided random number generator.
 """
 function Utils.generate_environment(
     b::DynamicAssortmentBenchmark, rng::AbstractRNG; kwargs...
 )
     instance = Instance(b, rng)
-    seed = rand(rng, 1:typemax(Int))
-    return Environment(instance; seed)
+    return Environment(instance)
 end
 
 """

--- a/src/DynamicAssortment/DynamicAssortment.jl
+++ b/src/DynamicAssortment/DynamicAssortment.jl
@@ -102,9 +102,7 @@ $TYPEDSIGNATURES
 Creates an [`Environment`](@ref) for the dynamic assortment benchmark.
 The instance is randomly generated using the provided random number generator.
 """
-function Utils.generate_environment(
-    b::DynamicAssortmentBenchmark, rng::AbstractRNG; kwargs...
-)
+function Utils.build_environment(b::DynamicAssortmentBenchmark, rng::AbstractRNG; kwargs...)
     instance = Instance(b, rng)
     return Environment(instance)
 end

--- a/src/DynamicAssortment/environment.jl
+++ b/src/DynamicAssortment/environment.jl
@@ -6,18 +6,13 @@ Environment for the dynamic assortment problem.
 # Fields
 $TYPEDFIELDS
 """
-@kwdef mutable struct Environment{I<:Instance,R<:AbstractRNG,S<:Union{Nothing,Int}} <:
-                      AbstractEnvironment
+@kwdef mutable struct Environment{I<:Instance} <: AbstractEnvironment
     "associated instance"
     instance::I
     "current step"
     step::Int
     "purchase history (used to update hype feature)"
     purchase_history::Vector{Int}
-    "rng"
-    rng::R
-    "seed for RNG"
-    seed::S
     "customer utility for each item"
     utility::Vector{Float64}
     "current full features"
@@ -31,25 +26,21 @@ $TYPEDSIGNATURES
 
 Creates an [`Environment`](@ref) from an [`Instance`](@ref) of the dynamic assortment benchmark.
 """
-function Environment(instance::Instance; seed=0, rng::AbstractRNG=MersenneTwister(seed))
+function Environment(instance::Instance)
     N = item_count(instance)
     (; prices, features, starting_hype_and_saturation) = instance
     full_features = vcat(
         reshape(prices[1:(end - 1)], 1, :), starting_hype_and_saturation, features
     )
     model = customer_choice_model(instance)
-    env = Environment(;
+    return Environment(;
         instance,
         step=1,
         purchase_history=Int[],
-        rng=rng,
-        seed=seed,
         utility=model(full_features),
         features=full_features,
         d_features=zeros(2, N),
     )
-    Utils.reset!(env; reset_rng=true)
-    return env
 end
 
 customer_choice_model(env::Environment) = customer_choice_model(env.instance)
@@ -144,36 +135,26 @@ end
 """
 $TYPEDSIGNATURES
 
-Outputs the seed of the environment.
-"""
-Utils.get_seed(env::Environment) = env.seed
-
-"""
-$TYPEDSIGNATURES
-
 Resets the environment to the initial state:
-- reset the rng if `reset_rng` is true
 - reset the step to 1
 - reset the features to the initial features
 - reset the change in features to zero
 - reset the utility to the initial utility
 - clear the purchase history
 """
-function Utils.reset!(env::Environment; reset_rng=false, seed=env.seed)
-    reset_rng && Random.seed!(env.rng, seed)
-
+function Utils.reset!(env::Environment, ::AbstractRNG)
     env.step = 1
 
     (; prices, starting_hype_and_saturation, features) = env.instance
-    features = vcat(
+    full_features = vcat(
         reshape(prices[1:(end - 1)], 1, :), starting_hype_and_saturation, features
     )
-    env.features .= features
+    env.features .= full_features
 
     env.d_features .= 0.0
 
     model = customer_choice_model(env)
-    env.utility .= model(features)
+    env.utility .= model(full_features)
 
     empty!(env.purchase_history)
     return nothing
@@ -224,12 +205,11 @@ $TYPEDSIGNATURES
 Performs one step in the environment given an assortment.
 Draw an item according to the customer choice model and updates the environment state.
 """
-function Utils.step!(env::Environment, assortment::BitVector)
+function Utils.step!(env::Environment, assortment::BitVector, rng::AbstractRNG)
     @assert !Utils.is_terminated(env) "Environment is terminated, cannot act!"
-    r = prices(env)
     probs = choice_probabilities(env, assortment)
-    item = rand(env.rng, Categorical(probs))
-    reward = r[item]
+    item = rand(rng, Categorical(probs))
+    reward = prices(env)[item]
     buy_item!(env, item)
     return reward
 end

--- a/src/DynamicVehicleScheduling/DynamicVehicleScheduling.jl
+++ b/src/DynamicVehicleScheduling/DynamicVehicleScheduling.jl
@@ -13,7 +13,7 @@ using IterTools: partition
 using JSON
 using JuMP
 using Printf: @printf, @sprintf
-using Random: Random, AbstractRNG, MersenneTwister, seed!, randperm
+using Random: Random, AbstractRNG, Xoshiro, seed!, randperm
 using Requires: @require
 using Statistics: mean, quantile
 
@@ -59,30 +59,32 @@ include("policy.jl")
 $TYPEDSIGNATURES
 
 Generate environments for the dynamic vehicle scheduling benchmark.
-Reads from pre-existing DVRPTW files and creates [`DVSPEnv`](@ref) environments.
+Reads from pre-existing DVRPTW files and creates [`DVSPEnv`](@ref) environments
+wrapped in [`SeededEnvironment`](@ref) for reproducible episode replay.
 """
 function Utils.generate_environments(
-    b::DynamicVehicleSchedulingBenchmark,
-    n::Int;
-    seed=nothing,
-    rng=MersenneTwister(seed),
-    kwargs...,
+    b::DynamicVehicleSchedulingBenchmark, n::Int; seed=nothing, rng=Xoshiro(seed), kwargs...
 )
     (; max_requests_per_epoch, Δ_dispatch, epoch_duration, two_dimensional_features) = b
     files = readdir(datadep"dvrptw"; join=true)
     n = min(n, length(files))
+    gen_rng = Xoshiro(rand(rng, UInt))
+    seed_rng = Xoshiro(rand(rng, UInt))
     return [
-        generate_environment(
-            b,
-            Instance(
-                read_vsp_instance(files[i]);
-                max_requests_per_epoch,
-                Δ_dispatch,
-                epoch_duration,
-                two_dimensional_features,
-            ),
-            rng;
-            kwargs...,
+        Utils.SeededEnvironment(
+            generate_environment(
+                b,
+                Instance(
+                    read_vsp_instance(files[i]);
+                    max_requests_per_epoch,
+                    Δ_dispatch,
+                    epoch_duration,
+                    two_dimensional_features,
+                ),
+                gen_rng;
+                kwargs...,
+            );
+            seed=rand(seed_rng, UInt),
         ) for i in 1:n
     ]
 end
@@ -91,13 +93,11 @@ end
 $TYPEDSIGNATURES
 
 Creates an environment from an [`Instance`](@ref) of the dynamic vehicle scheduling benchmark.
-The seed of the environment is randomly generated using the provided random number generator.
 """
 function generate_environment(
     ::DynamicVehicleSchedulingBenchmark, instance::Instance, rng::AbstractRNG; kwargs...
 )
-    seed = rand(rng, 1:typemax(Int))
-    return DVSPEnv(instance; seed)
+    return DVSPEnv(instance, rng)
 end
 
 """
@@ -119,8 +119,11 @@ as a `Vector{DataSample}`. Set `reset_env=true` (default) to reset the environme
 before solving, or `reset_env=false` to plan from the current state.
 """
 function Utils.generate_anticipative_solver(::DynamicVehicleSchedulingBenchmark)
-    return (env; reset_env=true, kwargs...) -> begin
-        _, trajectory = anticipative_solver(env; reset_env, kwargs...)
+    return (env::Utils.SeededEnvironment; reset_env=true, kwargs...) -> begin
+        # Anchor to the wrapper's initial seed so the solved scenario is reproducible,
+        # then solve from that state (the env was already reset).
+        reset_env && Utils.reset_to_initial!(env)
+        _, trajectory = anticipative_solver(env.env, env.rng; reset_env=false, kwargs...)
         return trajectory
     end
 end

--- a/src/DynamicVehicleScheduling/DynamicVehicleScheduling.jl
+++ b/src/DynamicVehicleScheduling/DynamicVehicleScheduling.jl
@@ -72,8 +72,7 @@ function Utils.generate_environments(
     seed_rng = Xoshiro(rand(rng, UInt))
     return [
         Utils.SeededEnvironment(
-            generate_environment(
-                b,
+            DVSPEnv(
                 Instance(
                     read_vsp_instance(files[i]);
                     max_requests_per_epoch,
@@ -81,23 +80,11 @@ function Utils.generate_environments(
                     epoch_duration,
                     two_dimensional_features,
                 ),
-                gen_rng;
-                kwargs...,
+                gen_rng,
             );
             seed=rand(seed_rng, UInt),
         ) for i in 1:n
     ]
-end
-
-"""
-$TYPEDSIGNATURES
-
-Creates an environment from an [`Instance`](@ref) of the dynamic vehicle scheduling benchmark.
-"""
-function generate_environment(
-    ::DynamicVehicleSchedulingBenchmark, instance::Instance, rng::AbstractRNG; kwargs...
-)
-    return DVSPEnv(instance, rng)
 end
 
 """

--- a/src/DynamicVehicleScheduling/anticipative_solver.jl
+++ b/src/DynamicVehicleScheduling/anticipative_solver.jl
@@ -45,16 +45,16 @@ For this, it uses the current environment history, so make sure that the environ
 """
 function anticipative_solver(
     env::DVSPEnv,
+    rng::AbstractRNG,
     scenario=env.scenario;
     model_builder=highs_model,
     two_dimensional_features=env.instance.two_dimensional_features,
     reset_env=true,
     nb_epochs=nothing,
-    seed=get_seed(env),
     verbose=false,
 )
     if reset_env
-        reset!(env; reset_rng=true, seed)
+        reset!(env, rng)
         scenario = env.scenario
     end
 

--- a/src/DynamicVehicleScheduling/environment.jl
+++ b/src/DynamicVehicleScheduling/environment.jl
@@ -1,26 +1,21 @@
-mutable struct DVSPEnv{S<:DVSPState,R<:AbstractRNG,SS} <: Utils.AbstractEnvironment
+mutable struct DVSPEnv{S<:DVSPState} <: Utils.AbstractEnvironment
     "associated instance"
     instance::Instance
     "current state"
     state::S
     "scenario the environment will use when not given a specific one"
     scenario::Scenario
-    "random number generator"
-    rng::R
-    "seed for the environment"
-    seed::SS
 end
 
 """
 $TYPEDSIGNATURES
 
-Constructor for [`DVSPEnv`](@ref).
+Constructor for [`DVSPEnv`](@ref). Draws an initial scenario from `rng`.
 """
-function DVSPEnv(instance::Instance; seed=nothing)
-    rng = MersenneTwister(seed)
+function DVSPEnv(instance::Instance, rng::AbstractRNG)
     scenario = Utils.generate_scenario(instance; rng)
     initial_state = DVSPState(instance; scenario[1]...)
-    return DVSPEnv(instance, initial_state, scenario, rng, seed)
+    return DVSPEnv(instance, initial_state, scenario)
 end
 
 """
@@ -28,18 +23,15 @@ $TYPEDSIGNATURES
 
 Constructor for [`DVSPEnv`](@ref) from a pre-existing scenario.
 """
-function DVSPEnv(instance::Instance, scenario::Scenario; seed=nothing)
-    rng = MersenneTwister(seed)
+function DVSPEnv(instance::Instance, scenario::Scenario)
     initial_state = DVSPState(instance; scenario[1]...)
-    return DVSPEnv(instance, initial_state, scenario, rng, seed)
+    return DVSPEnv(instance, initial_state, scenario)
 end
 
 currrent_epoch(env::DVSPEnv) = current_epoch(env.state)
 epoch_duration(env::DVSPEnv) = epoch_duration(env.instance)
 last_epoch(env::DVSPEnv) = last_epoch(env.instance)
 Δ_dispatch(env::DVSPEnv) = Δ_dispatch(env.instance)
-
-Utils.get_seed(env::DVSPEnv) = env.seed
 
 """
 $TYPEDSIGNATURES
@@ -80,14 +72,10 @@ Utils.is_terminated(env::DVSPEnv) = current_epoch(env) > last_epoch(env)
 """
 $TYPEDSIGNATURES
 
-Reset the environment to its initial state.
-Also reset the rng to `seed` if `reset_rng` is set to true.
+Reset the environment to its initial state, drawing a fresh scenario from `rng`.
 """
-function Utils.reset!(env::DVSPEnv; seed=get_seed(env), reset_rng=false)
-    if reset_rng
-        Random.seed!(env.rng, seed)
-    end
-    env.scenario = Utils.generate_scenario(env; rng=env.rng)
+function Utils.reset!(env::DVSPEnv, rng::AbstractRNG)
+    env.scenario = Utils.generate_scenario(env; rng)
     reset_state!(env.state, env.instance; env.scenario[1]...)
     return nothing
 end
@@ -96,12 +84,13 @@ end
 $TYPEDSIGNATURES
 
 Remove dispatched customers, advance time, and add new requests to the environment.
+The transition is deterministic (already sampled beforehand) given `env.scenario`, the `rng` argument is ignored.
 """
-function Utils.step!(env::DVSPEnv, routes, scenario=env.scenario)
+function Utils.step!(env::DVSPEnv, routes, ::AbstractRNG)
     reward = -apply_routes!(env.state, routes)
     env.state.current_epoch += 1
     if !Utils.is_terminated(env)
-        add_new_customers!(env.state, env.instance; scenario[current_epoch(env)]...)
+        add_new_customers!(env.state, env.instance; env.scenario[current_epoch(env)]...)
     end
     return reward
 end

--- a/src/DynamicVehicleScheduling/features.jl
+++ b/src/DynamicVehicleScheduling/features.jl
@@ -99,7 +99,7 @@ function quantile_reachable_new_requests(
     # Store reachability percentages for each customer across samples
     reachability_matrix = zeros(Float64, n_current, n_samples)
 
-    rng = MersenneTwister(42)
+    rng = Xoshiro(42)
     for s in 1:n_samples
         # Sample new requests similar to scenario generation
         coordinate_indices = sample_indices(rng, max_requests_per_epoch, N)

--- a/src/DynamicVehicleScheduling/scenario.jl
+++ b/src/DynamicVehicleScheduling/scenario.jl
@@ -16,7 +16,7 @@ function Base.getindex(scenario::Scenario, idx::Integer)
 end
 
 function Utils.generate_scenario(
-    instance::Instance; seed=nothing, rng::AbstractRNG=MersenneTwister(seed)
+    instance::Instance; seed=nothing, rng::AbstractRNG=Xoshiro(seed)
 )
     (; Δ_dispatch, static_instance, last_epoch, epoch_duration, max_requests_per_epoch) =
         instance

--- a/src/Maintenance/Maintenance.jl
+++ b/src/Maintenance/Maintenance.jl
@@ -116,7 +116,7 @@ $TYPEDSIGNATURES
 Creates an [`Environment`](@ref) for the maintenance benchmark.
 The instance is randomly generated using the provided random number generator.
 """
-function Utils.generate_environment(b::MaintenanceBenchmark, rng::AbstractRNG; kwargs...)
+function Utils.build_environment(b::MaintenanceBenchmark, rng::AbstractRNG; kwargs...)
     instance = Instance(b, rng)
     return Environment(instance)
 end

--- a/src/Maintenance/Maintenance.jl
+++ b/src/Maintenance/Maintenance.jl
@@ -6,7 +6,7 @@ using DocStringExtensions: TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES, SIGNATURES
 using Distributions: Uniform, Categorical
 using Flux: Chain, Dense
 using LinearAlgebra: dot
-using Random: Random, AbstractRNG, MersenneTwister
+using Random: Random, AbstractRNG, Xoshiro
 using Statistics: mean
 
 using Combinatorics: combinations
@@ -114,12 +114,11 @@ end
 $TYPEDSIGNATURES
 
 Creates an [`Environment`](@ref) for the maintenance benchmark.
-The instance and seed are randomly generated using the provided random number generator.
+The instance is randomly generated using the provided random number generator.
 """
 function Utils.generate_environment(b::MaintenanceBenchmark, rng::AbstractRNG; kwargs...)
     instance = Instance(b, rng)
-    seed = rand(rng, 1:typemax(Int))
-    return Environment(instance; seed)
+    return Environment(instance)
 end
 
 """

--- a/src/Maintenance/environment.jl
+++ b/src/Maintenance/environment.jl
@@ -6,18 +6,13 @@ Environment for the maintenance problem.
 # Fields
 $TYPEDFIELDS
 """
-@kwdef mutable struct Environment{R<:AbstractRNG,S<:Union{Nothing,Int}} <:
-                      AbstractEnvironment
+@kwdef mutable struct Environment <: AbstractEnvironment
     "associated instance"
     instance::Instance
     "current step"
     step::Int
     "degradation state"
     degradation_state::Vector{Int}
-    "rng"
-    rng::R
-    "seed for RNG"
-    seed::S
 end
 
 """
@@ -25,11 +20,9 @@ $TYPEDSIGNATURES
 
 Creates an [`Environment`](@ref) from an [`Instance`](@ref) of the maintenance benchmark.
 """
-function Environment(instance::Instance; seed=0, rng::AbstractRNG=MersenneTwister(seed))
+function Environment(instance::Instance)
     degradation_state = copy(starting_state(instance))
-    env = Environment(; instance, step=1, degradation_state, rng=rng, seed=seed)
-    Utils.reset!(env; reset_rng=true)
-    return env
+    return Environment(; instance, step=1, degradation_state)
 end
 
 component_count(env::Environment) = component_count(env.instance)
@@ -43,13 +36,12 @@ starting_state(env::Environment) = starting_state(env.instance)
 
 """
 $TYPEDSIGNATURES
-Draw random degradations for all components.
+Draw random degradations for all components using `rng`.
 """
-function degrad!(env::Environment)
+function degrad!(env::Environment, rng::AbstractRNG)
     N = component_count(env)
     n = degradation_levels(env)
     p = degradation_probability(env)
-    rng = env.rng
 
     for i in 1:N
         if env.degradation_state[i] < n && rand(rng) < p
@@ -98,20 +90,11 @@ end
 """
 $TYPEDSIGNATURES
 
-Outputs the seed of the environment.
-"""
-Utils.get_seed(env::Environment) = env.seed
-
-"""
-$TYPEDSIGNATURES
-
 Resets the environment to the initial state:
-- reset the rng if `reset_rng` is true
 - reset the step to 1
 - reset the degradation state to the starting state
 """
-function Utils.reset!(env::Environment; reset_rng=false, seed=env.seed)
-    reset_rng && Random.seed!(env.rng, seed)
+function Utils.reset!(env::Environment, ::AbstractRNG)
     env.step = 1
     env.degradation_state .= starting_state(env)
     return nothing
@@ -145,10 +128,10 @@ $TYPEDSIGNATURES
 Performs one step in the environment given a maintenance.
 Draw random degradations for components that are not maintained.
 """
-function Utils.step!(env::Environment, maintenance::BitVector)
+function Utils.step!(env::Environment, maintenance::BitVector, rng::AbstractRNG)
     @assert !Utils.is_terminated(env) "Environment is terminated, cannot act!"
     cost = maintenance_cost(env, maintenance) + degradation_cost(env)
-    degrad!(env)
+    degrad!(env, rng)
     maintain!(env, maintenance)
     env.step += 1
     return cost

--- a/src/PortfolioOptimization/PortfolioOptimization.jl
+++ b/src/PortfolioOptimization/PortfolioOptimization.jl
@@ -7,7 +7,7 @@ using Flux: Chain, Dense
 using Ipopt: Ipopt
 using JuMP: @variable, @objective, @constraint, optimize!, value, Model, set_silent
 using LinearAlgebra: I, dot
-using Random: Random, AbstractRNG, MersenneTwister
+using Random: Random, AbstractRNG, Xoshiro
 
 """
 $TYPEDEF
@@ -50,7 +50,7 @@ Constructor for [`PortfolioOptimizationBenchmark`](@ref).
 function PortfolioOptimizationBenchmark(;
     d::Int=50, p::Int=5, deg::Int=1, ν::Float32=1.0f0, seed=0
 )
-    rng = MersenneTwister(seed)
+    rng = Xoshiro(seed)
     f = randn(rng, Float32, 4)
     L = Float32.(rand(rng, Uniform(-0.0025ν, 0.0025ν), d, 4))
     Σ = L * L' + (0.01f0ν)^2 * I

--- a/src/StochasticVehicleScheduling/StochasticVehicleScheduling.jl
+++ b/src/StochasticVehicleScheduling/StochasticVehicleScheduling.jl
@@ -28,7 +28,7 @@ using Graphs:
 using JuMP:
     JuMP, Model, @variable, @objective, @constraint, optimize!, value, set_silent, dual
 using Printf: @printf
-using Random: Random, AbstractRNG, MersenneTwister
+using Random: Random, AbstractRNG, Xoshiro
 using SparseArrays: sparse, SparseMatrixCSC
 using Statistics: quantile, mean
 

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -5,7 +5,7 @@ using Flux: softplus
 using HiGHS: HiGHS
 using JuMP: Model
 using LinearAlgebra: dot
-using Random: Random, MersenneTwister, AbstractRNG
+using Random: Random, Xoshiro, AbstractRNG
 using SCIP: SCIP
 using SimpleWeightedGraphs: SimpleWeightedDiGraph
 using StatsBase: StatsBase
@@ -13,7 +13,8 @@ using Statistics: mean
 
 include("data_sample.jl")
 include("maximizers.jl")
-include("environment.jl")
+include("environment/abstract_environment.jl")
+include("environment/seeded_environment.jl")
 include("policy.jl")
 include("interface/abstract_benchmark.jl")
 include("interface/static_benchmark.jl")
@@ -27,7 +28,8 @@ export DataSample, Policy
 export evaluate_policy!
 export TopKMaximizer, one_hot_argmax
 
-export AbstractEnvironment, get_seed, is_terminated, observe, reset!, step!
+export AbstractEnvironment, SeededEnvironment
+export get_seed, is_terminated, observe, reset!, reset_to_initial!, step!
 
 export AbstractBenchmark,
     AbstractStaticBenchmark, AbstractStochasticBenchmark, AbstractDynamicBenchmark

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -38,7 +38,7 @@ export ExogenousStochasticBenchmark,
 export generate_instance, generate_sample, generate_dataset
 export generate_statistical_model, generate_maximizer
 export generate_scenario, generate_context
-export generate_environment, generate_environments
+export build_environment, generate_environment, generate_environments
 export SampleAverageApproximation
 export generate_baseline_policies
 export generate_anticipative_solver, generate_parametric_anticipative_solver

--- a/src/Utils/environment/abstract_environment.jl
+++ b/src/Utils/environment/abstract_environment.jl
@@ -6,17 +6,6 @@ Abstract type for environments in decision-focused learning benchmarks.
 abstract type AbstractEnvironment end
 
 """
-$TYPEDSIGNATURES
-
-Seed accessor for environments.
-By default, environments have no seed.
-Override this method to provide a seed for the environment.
-"""
-function get_seed(::AbstractEnvironment)
-    return nothing
-end
-
-"""
     is_terminated(env::AbstractEnvironment) --> Bool
 
 Check if the environment has reached a terminal state.
@@ -34,19 +23,21 @@ This function should return a tuple of two elements:
 function observe end
 
 """
-    reset!(env::AbstractEnvironment; reset_rng::Bool, seed=get_seed(env)) --> Nothing
+    reset!(env::AbstractEnvironment, rng::Random.AbstractRNG) --> Nothing
 
-Reset the environment to its initial state.
-If `reset_rng` is true, the random number generator is reset to the given `seed`.
+Reset the environment to a starting state using the provided random number generator.
 """
 function reset! end
 
 """
-    step!(env::AbstractEnvironment, action) --> Float64
+    step!(env::AbstractEnvironment, action, rng::Random.AbstractRNG) --> Float64
 
 Perform a step in the environment with the given action.
 Returns the reward received after taking the action.
 This function may also update the internal state of the environment.
+Implementations that use randomness during a transition must draw from the
+provided `rng` rather than any internal state. Deterministic implementations may
+ignore the `rng` argument.
 If the environment is terminated, it should raise an error.
 """
 function step! end

--- a/src/Utils/environment/seeded_environment.jl
+++ b/src/Utils/environment/seeded_environment.jl
@@ -37,7 +37,7 @@ seeded with `seed` (so `seed=nothing` produces an unseeded generator). Pass `rng
 explicitly to supply a different generator.
 """
 function SeededEnvironment(env::AbstractEnvironment; seed=nothing, rng=Random.Xoshiro(seed))
-    return SeededEnvironment(seed, rng, env)
+    return SeededEnvironment(isnothing(seed) ? nothing : UInt(seed), rng, env)
 end
 
 """

--- a/src/Utils/environment/seeded_environment.jl
+++ b/src/Utils/environment/seeded_environment.jl
@@ -1,0 +1,145 @@
+"""
+$TYPEDEF
+
+Wraps an [`AbstractEnvironment`](@ref) together with a random number generator and an
+optional seed, making episodes reproducible.
+
+The wrapper is the single owner of randomness: it threads its own `rng` into the
+wrapped environment's [`reset!`](@ref) and [`step!`](@ref), so the wrapped environment
+itself never needs to manage a seed. Resetting to the stored seed (see
+[`reset_to_initial!`](@ref)) replays the exact same episode, which is what
+[`evaluate_policy!`](@ref) relies on for reproducible evaluation.
+
+# Fields
+$TYPEDFIELDS
+"""
+struct SeededEnvironment{E<:AbstractEnvironment,R<:Random.AbstractRNG} <:
+       AbstractEnvironment
+    "seed (`nothing` if the environment is unseeded)"
+    seed::Union{UInt,Nothing}
+    "random number generator"
+    rng::R
+    "wrapped environment"
+    env::E
+end
+
+function Base.show(io::IO, env::SeededEnvironment)
+    show(io, env.env)
+    print(io, " (seed=$(env.seed))")
+    return nothing
+end
+
+"""
+$TYPEDSIGNATURES
+
+Wrap `env` in a [`SeededEnvironment`](@ref). By default the generator is a `Xoshiro`
+seeded with `seed` (so `seed=nothing` produces an unseeded generator). Pass `rng`
+explicitly to supply a different generator.
+"""
+function SeededEnvironment(env::AbstractEnvironment; seed=nothing, rng=Random.Xoshiro(seed))
+    return SeededEnvironment(seed, rng, env)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Return the stored seed.
+"""
+function get_seed(env::SeededEnvironment)
+    return env.seed
+end
+
+"""
+$TYPEDSIGNATURES
+
+Return the wrapper's random number generator.
+"""
+function get_rng(env::SeededEnvironment)
+    return env.rng
+end
+
+"""
+$TYPEDSIGNATURES
+
+Forward to the wrapped environment (see [`is_terminated`](@ref)).
+"""
+function is_terminated(env::SeededEnvironment)
+    return is_terminated(env.env)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Forward to the wrapped environment (see [`observe`](@ref)).
+"""
+function observe(env::SeededEnvironment)
+    return observe(env.env)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Reset the wrapped environment using the wrapper's current `rng` state. This advances
+the generator (it does not re-seed it), so successive calls produce different episodes.
+"""
+function reset!(env::SeededEnvironment)
+    return reset!(env.env, env.rng)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Reset the wrapped environment using the provided `rng` instead of the wrapper's own.
+"""
+function reset!(env::SeededEnvironment, rng::Random.AbstractRNG)
+    return reset!(env.env, rng)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Re-seed the wrapper's `rng` to `seed`, then reset the wrapped environment. Calling this
+with a fixed `seed` makes the resulting episode reproducible.
+"""
+function reset!(env::SeededEnvironment, seed::Integer)
+    Random.seed!(env.rng, seed)
+    return reset!(env.env, env.rng)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Equivalent to `reset!(env)`,
+i.e. reset from the current `rng` state without re-seeding.
+"""
+function reset!(env::SeededEnvironment, ::Nothing)
+    return reset!(env)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Reset to the wrapper's initial seed state, replaying the same episode. Equivalent to
+`reset!(env, get_seed(env))`.
+"""
+function reset_to_initial!(env::SeededEnvironment)
+    return reset!(env, env.seed)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Step the wrapped environment, drawing any transition randomness from the wrapper's `rng`.
+"""
+function step!(env::SeededEnvironment, action)
+    return step!(env.env, action, env.rng)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Step the wrapped environment using the provided `rng` instead of the wrapper's own.
+"""
+function step!(env::SeededEnvironment, action, rng::Random.AbstractRNG)
+    return step!(env.env, action, rng)
+end

--- a/src/Utils/interface/dynamic_benchmark.jl
+++ b/src/Utils/interface/dynamic_benchmark.jl
@@ -72,13 +72,16 @@ Primary entry point for dynamic training algorithms.
 Override when environments cannot be drawn independently (e.g. loading from files).
 """
 function generate_environments(
-    bench::AbstractDynamicBenchmark,
-    n::Int;
-    seed=nothing,
-    rng=MersenneTwister(seed),
-    kwargs...,
+    bench::AbstractDynamicBenchmark, n::Int; seed=nothing, kwargs...
 )
-    return [generate_environment(bench, rng; kwargs...) for _ in 1:n]
+    root_rng = Xoshiro(seed)
+    gen_rng = Xoshiro(rand(root_rng, UInt))
+    seed_rng = Xoshiro(rand(root_rng, UInt))
+    return [
+        SeededEnvironment(
+            generate_environment(bench, gen_rng; kwargs...); seed=rand(seed_rng, UInt)
+        ) for _ in 1:n
+    ]
 end
 
 """

--- a/src/Utils/interface/dynamic_benchmark.jl
+++ b/src/Utils/interface/dynamic_benchmark.jl
@@ -6,16 +6,17 @@ The `{exogenous}` parameter has the same meaning (whether uncertainty is indepen
 of decisions) as in [`AbstractStochasticBenchmark`](@ref).
 
 # Primary entry point
-- [`generate_environments`](@ref)`(bench, n; rng)`: mandatory (or implement
-  [`generate_environment`](@ref)`(bench, rng)`). The count-based default calls
-  [`generate_environment`](@ref) once per environment.
+- [`build_environment`](@ref)`(bench, rng)`: mandatory hook returning a single **bare**
+  environment. The framework wraps it in a [`SeededEnvironment`](@ref). Override
+  [`generate_environments`](@ref) instead when environments cannot be drawn independently.
 
 # Additional optional methods
-- [`generate_environment`](@ref)`(bench, rng)`: initialize a single rollout environment.
+- [`build_environment`](@ref)`(bench, rng)`: build a single bare rollout environment.
   Must return an [`AbstractEnvironment`](@ref) (see `environment.jl` for the full protocol:
-  [`reset!`](@ref), [`observe`](@ref), [`step!`](@ref), [`is_terminated`](@ref)).
-  Implement this instead of overriding [`generate_environments`](@ref) when environments
-  can be drawn independently.
+  [`reset!`](@ref), [`observe`](@ref), [`step!`](@ref), [`is_terminated`](@ref)). The
+  environment must not manage its own seed/rng: draw randomness from the passed `rng`.
+  Users obtain wrapped environments via [`generate_environment`](@ref) (one) or
+  [`generate_environments`](@ref) (many).
 - [`generate_baseline_policies`](@ref)`(bench)`: returns named baseline callables of
   signature `(env) -> Vector{DataSample}` (full trajectory rollout).
 - [`generate_anticipative_solver`](@ref)`(bench)`: returns a callable
@@ -55,21 +56,42 @@ const ExogenousDynamicBenchmark = AbstractDynamicBenchmark{true}
 const EndogenousDynamicBenchmark = AbstractDynamicBenchmark{false}
 
 """
-    generate_environment(::AbstractDynamicBenchmark, rng::AbstractRNG; kwargs...) -> AbstractEnvironment
+    build_environment(::AbstractDynamicBenchmark, rng::AbstractRNG; kwargs...) -> AbstractEnvironment
 
-Initialize a single environment for the given dynamic benchmark.
-Primary implementation target for the count-based [`generate_environments`](@ref) default.
-Override [`generate_environments`](@ref) directly when environments cannot be drawn
-independently (e.g. loading from files).
+Build a single environment for the given dynamic benchmark, drawing any
+randomness from `rng`. This is the implementation hook benchmark authors provide: the
+framework wraps the result in a [`SeededEnvironment`](@ref) (see [`generate_environment`](@ref)
+and [`generate_environments`](@ref)), so the returned environment must not manage its own
+seed or rng.
+
+Implement this for benchmarks whose environments are drawn independently. When
+environments cannot be drawn independently (e.g. loaded from files), override
+[`generate_environments`](@ref) instead.
 """
-function generate_environment end
+function build_environment end
 
 """
 $TYPEDSIGNATURES
 
-Generate `n` environments for the given dynamic benchmark.
-Primary entry point for dynamic training algorithms.
-Override when environments cannot be drawn independently (e.g. loading from files).
+Generate a single environment wrapped in a [`SeededEnvironment`](@ref), seeded from `seed`.
+Equivalent to `generate_environments(bench, 1; seed)[1]`.
+
+This should **not** be overridden: customize [`build_environment`](@ref) (independent environments)
+or [`generate_environments`](@ref) (non-independent environments) instead.
+"""
+function generate_environment(bench::AbstractDynamicBenchmark; seed=nothing, kwargs...)
+    return only(generate_environments(bench, 1; seed, kwargs...))
+end
+
+"""
+$TYPEDSIGNATURES
+
+Generate `n` environments for the given dynamic benchmark, each wrapped in a
+[`SeededEnvironment`](@ref). Primary entry point for dynamic training algorithms.
+
+The default implementation calls [`build_environment`](@ref) `n` times and wraps each
+result. Override this method when environments cannot be drawn independently (e.g. loading
+from files); an override must return already-wrapped [`SeededEnvironment`](@ref)s.
 """
 function generate_environments(
     bench::AbstractDynamicBenchmark, n::Int; seed=nothing, kwargs...
@@ -79,7 +101,7 @@ function generate_environments(
     seed_rng = Xoshiro(rand(root_rng, UInt))
     return [
         SeededEnvironment(
-            generate_environment(bench, gen_rng; kwargs...); seed=rand(seed_rng, UInt)
+            build_environment(bench, gen_rng; kwargs...); seed=rand(seed_rng, UInt)
         ) for _ in 1:n
     ]
 end

--- a/src/Utils/interface/dynamic_benchmark.jl
+++ b/src/Utils/interface/dynamic_benchmark.jl
@@ -6,12 +6,12 @@ The `{exogenous}` parameter has the same meaning (whether uncertainty is indepen
 of decisions) as in [`AbstractStochasticBenchmark`](@ref).
 
 # Primary entry point
-- [`build_environment`](@ref)`(bench, rng)`: mandatory hook returning a single **bare**
-  environment. The framework wraps it in a [`SeededEnvironment`](@ref). Override
-  [`generate_environments`](@ref) instead when environments cannot be drawn independently.
+- [`build_environment`](@ref)`(bench, rng)`: mandatory hook returning a single bare environment.
+  The framework wraps it in a [`SeededEnvironment`](@ref). Override [`generate_environments`](@ref)
+  instead when environments cannot be drawn independently.
 
 # Additional optional methods
-- [`build_environment`](@ref)`(bench, rng)`: build a single bare rollout environment.
+- [`build_environment`](@ref)`(bench, rng)`: build a single bare environment.
   Must return an [`AbstractEnvironment`](@ref) (see `environment.jl` for the full protocol:
   [`reset!`](@ref), [`observe`](@ref), [`step!`](@ref), [`is_terminated`](@ref)). The
   environment must not manage its own seed/rng: draw randomness from the passed `rng`.

--- a/src/Utils/interface/static_benchmark.jl
+++ b/src/Utils/interface/static_benchmark.jl
@@ -67,7 +67,7 @@ function generate_dataset(
     dataset_size::Int;
     target_policy=nothing,
     seed=nothing,
-    rng=MersenneTwister(seed),
+    rng=Xoshiro(seed),
     kwargs...,
 )
     return [

--- a/src/Utils/interface/stochastic_benchmark.jl
+++ b/src/Utils/interface/stochastic_benchmark.jl
@@ -215,7 +215,7 @@ by the `target_policy`:
 - `target_policy`: when provided, called as
   `target_policy(ctx_sample, scenarios)` to compute labels.
   Defaults to `nothing` (unlabeled samples).
-- `seed`: passed to `MersenneTwister` when `rng` is not provided.
+- `seed`: passed to `Xoshiro` when `rng` is not provided.
 - `rng`: random number generator; overrides `seed` when provided.
 - `kwargs...`: forwarded to [`generate_sample`](@ref).
 """
@@ -226,7 +226,7 @@ function generate_dataset(
     nb_scenarios::Int=1,
     contexts_per_instance::Int=1,
     seed=nothing,
-    rng=MersenneTwister(seed),
+    rng=Xoshiro(seed),
     kwargs...,
 )
     nb_instances == 0 && return DataSample[]
@@ -315,7 +315,7 @@ function generate_dataset(
     nb_instances::Int;
     target_policy=nothing,
     seed=nothing,
-    rng=MersenneTwister(seed),
+    rng=Xoshiro(seed),
     kwargs...,
 )
     nb_instances == 0 && return DataSample[]

--- a/src/Utils/policy.jl
+++ b/src/Utils/policy.jl
@@ -28,15 +28,10 @@ end
 """
 $TYPEDSIGNATURES
 
-Run the policy on the environment and return the total reward and a dataset of observations.
-By default, the environment is reset before running the policy.
+Run the policy from the environment's current state (without resetting), using `rng`
+for per-step randomness. Returns the total reward and a dataset of observations.
 """
-function evaluate_policy!(
-    policy, env::AbstractEnvironment; reset_env=true, seed=get_seed(env), kwargs...
-)
-    if reset_env
-        reset!(env; reset_rng=true, seed=seed)
-    end
+function rollout!(policy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...)
     total_reward = 0.0
     labeled_dataset = DataSample[]
     step = 0
@@ -44,8 +39,8 @@ function evaluate_policy!(
         step += 1
         y = policy(env; kwargs...)
         features, state = observe(env)
-        state_copy = deepcopy(state)  # To avoid mutation issues
-        reward = step!(env, y)
+        state_copy = deepcopy(state)
+        reward = step!(env, y, rng)
         sample = DataSample(; x=features, y=y, instance=state_copy, extra=(; reward, step))
         if isempty(labeled_dataset)
             labeled_dataset = typeof(sample)[sample]
@@ -60,20 +55,35 @@ end
 """
 $TYPEDSIGNATURES
 
-Evaluate the policy on the environment and return the total reward and a dataset of observations.
-By default, the environment is reset before running the policy.
+Run the policy on a [`SeededEnvironment`](@ref) and return the total reward and a
+dataset of observations. The environment is reset to its initial seed state before
+running, which makes the rollout reproducible. Pass `seed` to override the wrapper's
+stored seed for this evaluation. The wrapper's `rng` is the single source of
+randomness threaded into the underlying environment.
+"""
+function evaluate_policy!(policy, env::SeededEnvironment; seed=nothing, kwargs...)
+    isnothing(seed) ? reset_to_initial!(env) : reset!(env, seed)
+    return rollout!(policy, env.env, env.rng; kwargs...)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Evaluate the policy across multiple episodes. The first episode resets to the
+initial seed (or to `seed` if provided), subsequent episodes continue from the
+wrapper's evolving rng state.
 """
 function evaluate_policy!(
-    policy, env::AbstractEnvironment, episodes::Int; seed=get_seed(env), kwargs...
+    policy, env::SeededEnvironment, episodes::Int; seed=nothing, kwargs...
 )
     rewards = zeros(Float64, episodes)
     datasets = map(1:episodes) do _i
         if _i == 1
-            reset!(env; reset_rng=true, seed=seed)
+            isnothing(seed) ? reset_to_initial!(env) : reset!(env, seed)
         else
-            reset!(env; reset_rng=false)
+            reset!(env)
         end
-        reward, dataset = evaluate_policy!(policy, env; reset_env=false, kwargs...)
+        reward, dataset = rollout!(policy, env.env, env.rng; kwargs...)
         rewards[_i] = reward
         return dataset
     end
@@ -83,11 +93,10 @@ end
 """
 $TYPEDSIGNATURES
 
-Run the policy on the environments and return the total rewards and a dataset of observations.
-By default, the environments are reset before running the policy.
+Run the policy across a collection of [`SeededEnvironment`](@ref)s.
 """
 function evaluate_policy!(
-    policy, envs::Vector{<:AbstractEnvironment}, episodes::Int=1; kwargs...
+    policy, envs::Vector{<:SeededEnvironment}, episodes::Int=1; kwargs...
 )
     E = length(envs)
     avg_rewards = zeros(Float64, E)

--- a/src/Warcraft/Warcraft.jl
+++ b/src/Warcraft/Warcraft.jl
@@ -41,7 +41,7 @@ function Utils.generate_dataset(
     dataset_size::Int=10;
     target_policy=nothing,
     seed=nothing,
-    rng=MersenneTwister(seed),
+    rng=Xoshiro(seed),
     kwargs...,
 )
     decompressed_path = datadep"warcraft/data"

--- a/test/dynamic_assortment.jl
+++ b/test/dynamic_assortment.jl
@@ -277,6 +277,10 @@ end
 
     # Generate test data
     environments = generate_environments(b, 10; seed=0)
+    @test environments isa Vector{<:SeededEnvironment}
+    single = generate_environment(b; seed=0)
+    @test single isa SeededEnvironment
+    @test get_seed(single) == get_seed(generate_environments(b, 1; seed=0)[1])
 
     # Get policies
     policies = generate_baseline_policies(b)

--- a/test/dynamic_assortment.jl
+++ b/test/dynamic_assortment.jl
@@ -28,7 +28,7 @@ end
 
 @testset "DynamicAssortment - Instance Generation" begin
     b = DynamicAssortmentBenchmark(; N=5, d=3, K=2)
-    rng = MersenneTwister(42)
+    rng = Xoshiro(42)
 
     instance = DAP.Instance(b, rng)
 
@@ -53,14 +53,13 @@ end
 
 @testset "DynamicAssortment - Environment Initialization" begin
     b = DynamicAssortmentBenchmark(; N=5, d=2, K=2, max_steps=10)
-    instance = DAP.Instance(b, MersenneTwister(42))
+    instance = DAP.Instance(b, Xoshiro(42))
 
-    env = DAP.Environment(instance; seed=123)
+    env = DAP.Environment(instance)
 
     # Test initial state
     @test env.step == 1
     @test isempty(env.purchase_history)
-    @test env.seed == 123
     @test !is_terminated(env)
 
     # Test features structure: [prices; hype_saturation; static_features]
@@ -80,8 +79,8 @@ end
 
 @testset "DynamicAssortment - Environment Reset" begin
     b = DynamicAssortmentBenchmark(; N=3, d=1, K=2, max_steps=5)
-    instance = DAP.Instance(b, MersenneTwister(42))
-    env = DAP.Environment(instance; seed=123)
+    instance = DAP.Instance(b, Xoshiro(42))
+    env = DAP.Environment(instance)
 
     # Modify environment state
     env.step = 3
@@ -89,7 +88,7 @@ end
     env.features[2, 1] *= 1.5  # Modify hype
 
     # Reset environment
-    reset!(env)
+    reset!(env, Xoshiro(123))
 
     # Check reset state
     @test env.step == 1
@@ -107,8 +106,8 @@ end
 
 @testset "DynamicAssortment - Hype Update Logic" begin
     b = DynamicAssortmentBenchmark(; N=5, d=1, K=2)
-    instance = DAP.Instance(b, MersenneTwister(42))
-    env = DAP.Environment(instance; seed=123)
+    instance = DAP.Instance(b, Xoshiro(42))
+    env = DAP.Environment(instance)
 
     # Test hype update with no history
     hype = DAP.hype_update(env)
@@ -135,8 +134,8 @@ end
 
 @testset "DynamicAssortment - Choice Probabilities" begin
     b = DynamicAssortmentBenchmark(; N=3, d=1, K=2)
-    instance = DAP.Instance(b, MersenneTwister(42))
-    env = DAP.Environment(instance; seed=123)
+    instance = DAP.Instance(b, Xoshiro(42))
+    env = DAP.Environment(instance)
 
     # Test with full assortment
     assortment = trues(3)
@@ -167,8 +166,8 @@ end
 
 @testset "DynamicAssortment - Expected Revenue" begin
     b = DynamicAssortmentBenchmark(; N=3, d=1, K=2)
-    instance = DAP.Instance(b, MersenneTwister(42))
-    env = DAP.Environment(instance; seed=123)
+    instance = DAP.Instance(b, Xoshiro(42))
+    env = DAP.Environment(instance)
 
     # Test with full assortment
     assortment = trues(3)
@@ -183,14 +182,15 @@ end
 
 @testset "DynamicAssortment - Environment Step" begin
     b = DynamicAssortmentBenchmark(; N=3, d=1, K=2, max_steps=5)
-    instance = DAP.Instance(b, MersenneTwister(42))
-    env = DAP.Environment(instance; seed=123)
+    instance = DAP.Instance(b, Xoshiro(42))
+    env = DAP.Environment(instance)
 
     initial_step = env.step
     assortment = trues(3)
+    rng = Xoshiro(123)
 
     # Take a step
-    reward = step!(env, assortment)
+    reward = step!(env, assortment, rng)
 
     # Check step progression
     @test env.step == initial_step + 1
@@ -208,20 +208,20 @@ end
     # Test termination
     for _ in 1:(DAP.max_steps(env) - 1)
         if !is_terminated(env)
-            step!(env, assortment)
+            step!(env, assortment, rng)
         end
     end
     @test is_terminated(env)
 
     # Test error on terminated environment
-    @test_throws AssertionError step!(env, assortment)
+    @test_throws AssertionError step!(env, assortment, rng)
 end
 
 @testset "DynamicAssortment - Endogenous vs Exogenous" begin
     # Test endogenous environment (features change with purchases)
     b_endo = DynamicAssortmentBenchmark(; N=3, d=1, K=2, exogenous=false)
-    instance_endo = DAP.Instance(b_endo, MersenneTwister(42))
-    env_endo = DAP.Environment(instance_endo; seed=123)
+    instance_endo = DAP.Instance(b_endo, Xoshiro(42))
+    env_endo = DAP.Environment(instance_endo)
 
     initial_features_endo = copy(env_endo.features)
     DAP.buy_item!(env_endo, 1)
@@ -231,8 +231,8 @@ end
 
     # Test exogenous environment (features don't change with purchases)
     b_exo = DynamicAssortmentBenchmark(; N=3, d=1, K=2, exogenous=true)
-    instance_exo = DAP.Instance(b_exo, MersenneTwister(42))
-    env_exo = DAP.Environment(instance_exo; seed=123)
+    instance_exo = DAP.Instance(b_exo, Xoshiro(42))
+    env_exo = DAP.Environment(instance_exo)
 
     initial_features_exo = copy(env_exo.features)
     DAP.buy_item!(env_exo, 1)
@@ -243,8 +243,8 @@ end
 
 @testset "DynamicAssortment - Observation" begin
     b = DynamicAssortmentBenchmark(; N=3, d=2, max_steps=10)
-    instance = DAP.Instance(b, MersenneTwister(42))
-    env = DAP.Environment(instance; seed=123)
+    instance = DAP.Instance(b, Xoshiro(42))
+    env = DAP.Environment(instance)
 
     features, state = observe(env)
 
@@ -300,14 +300,14 @@ end
 
     # Test policy output format
     env = environments[1]
-    reset!(env)
+    reset_to_initial!(env)
 
-    expert_action = expert(env)
-    greedy_action = greedy(env)
-    @test length(expert_action) == DAP.item_count(env)
-    @test length(greedy_action) == DAP.item_count(env)
-    @test sum(expert_action) == DAP.assortment_size(env)
-    @test sum(greedy_action) == DAP.assortment_size(env)
+    expert_action = expert(env.env)
+    greedy_action = greedy(env.env)
+    @test length(expert_action) == DAP.item_count(env.env)
+    @test length(greedy_action) == DAP.item_count(env.env)
+    @test sum(expert_action) == DAP.assortment_size(env.env)
+    @test sum(greedy_action) == DAP.assortment_size(env.env)
 end
 
 @testset "DynamicAssortment - generate_dataset with environments (exogenous)" begin

--- a/test/dynamic_vsp.jl
+++ b/test/dynamic_vsp.jl
@@ -44,7 +44,7 @@
     @test size(x2, 1) == 27
 
     solution = generate_anticipative_solver(b)(env)
-    reset!(env; reset_rng=true)
+    reset_to_initial!(env)
     cost = sum(step!(env, sample.y) for sample in solution)
     cost2 = sum(sample.reward for sample in solution)
     @test isapprox(cost, cost2; atol=1e-5)

--- a/test/dynamic_vsp.jl
+++ b/test/dynamic_vsp.jl
@@ -9,6 +9,8 @@
     @test !is_endogenous(b)
 
     environments = generate_environments(b, 10; seed=0)
+    @test environments isa Vector{<:SeededEnvironment}
+    @test generate_environment(b; seed=0) isa SeededEnvironment
 
     env = environments[1]
     get_seed(env)

--- a/test/environment.jl
+++ b/test/environment.jl
@@ -1,0 +1,145 @@
+const DFLUtils = DecisionFocusedLearningBenchmarks.Utils
+
+mutable struct SeededMockEnv <: DFLUtils.AbstractEnvironment
+    max_steps::Int
+    step::Int
+    state::Float64
+end
+SeededMockEnv(; max_steps::Int=5) = SeededMockEnv(max_steps, 0, 0.0)
+
+DFLUtils.is_terminated(e::SeededMockEnv) = e.step >= e.max_steps
+DFLUtils.observe(e::SeededMockEnv) = ([e.state], e.step)
+function DFLUtils.reset!(e::SeededMockEnv, rng::AbstractRNG)
+    e.step = 0
+    e.state = rand(rng)
+    return nothing
+end
+function DFLUtils.step!(e::SeededMockEnv, action, rng::AbstractRNG)
+    e.step += 1
+    r = rand(rng)
+    e.state += r
+    return r
+end
+
+function run_episode!(senv)
+    reset_to_initial!(senv)
+    rewards = Float64[]
+    while !is_terminated(senv)
+        push!(rewards, step!(senv, nothing))
+    end
+    return rewards
+end
+
+@testset "SeededEnvironment" begin
+    @testset "Construction and accessors" begin
+        e = SeededMockEnv()
+        senv = SeededEnvironment(e; seed=42)
+        @test senv isa AbstractEnvironment
+        @test senv.env === e
+        @test get_seed(senv) == 42
+        @test DFLUtils.get_rng(senv) isa Xoshiro
+        @test occursin("seed=", sprint(show, senv))
+
+        # Integer seeds are accepted and stored as UInt
+        @test get_seed(SeededEnvironment(SeededMockEnv(); seed=7)) === UInt(7)
+        @test get_seed(SeededEnvironment(SeededMockEnv(); seed=UInt(7))) === UInt(7)
+
+        # Unseeded wrapper
+        @test get_seed(SeededEnvironment(SeededMockEnv())) === nothing
+
+        # Explicit rng is used as-is
+        myrng = Xoshiro(123)
+        senv2 = SeededEnvironment(SeededMockEnv(); seed=1, rng=myrng)
+        @test DFLUtils.get_rng(senv2) === myrng
+    end
+
+    @testset "Delegation to wrapped env" begin
+        senv = SeededEnvironment(SeededMockEnv(; max_steps=3); seed=0)
+        reset_to_initial!(senv)
+        @test is_terminated(senv) == is_terminated(senv.env)
+        @test observe(senv) == observe(senv.env)
+        @test !is_terminated(senv)
+        steps = 0
+        while !is_terminated(senv)
+            step!(senv, nothing)
+            steps += 1
+        end
+        @test is_terminated(senv)
+        @test steps == 3
+    end
+
+    @testset "reset! variants" begin
+        # Integer seed: re-seeds the wrapper rng to that seed, then resets
+        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        reset!(senv, 7)
+        s7a = senv.env.state
+        reset!(senv, 7)
+        s7b = senv.env.state
+        reset!(senv, 8)
+        s8 = senv.env.state
+        @test s7a == s7b
+        @test s7a != s8
+        @test s7a == rand(Xoshiro(7))   # confirms env.rng was seeded to 7 then drawn
+        @test senv.env.step == 0
+
+        # rng argument: resets using the provided rng, not the wrapper's
+        e = SeededMockEnv()
+        senv = SeededEnvironment(e; seed=0)
+        reset!(senv, Xoshiro(99))
+        @test e.state == rand(Xoshiro(99))
+
+        # no-arg reset!: uses the wrapper's current rng state (advances, does not re-seed)
+        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        reset_to_initial!(senv)
+        s1 = senv.env.state
+        reset!(senv)
+        s2 = senv.env.state
+        @test s1 != s2
+
+        # reset!(env, nothing) is equivalent to reset!(env) (no re-seeding)
+        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        Random.seed!(DFLUtils.get_rng(senv), 123)
+        reset!(senv, nothing)
+        sa = senv.env.state
+        Random.seed!(DFLUtils.get_rng(senv), 123)
+        reset!(senv)
+        sb = senv.env.state
+        @test sa == sb
+    end
+
+    @testset "step! variants" begin
+        # step! with explicit rng uses that rng
+        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        reset!(senv, 0)
+        r = step!(senv, nothing, Xoshiro(5))
+        @test r == rand(Xoshiro(5))
+        @test senv.env.step == 1
+
+        # step! without rng uses the wrapper rng (reproducible from the same seed)
+        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        reset_to_initial!(senv)
+        r1 = step!(senv, nothing)
+        reset_to_initial!(senv)
+        r2 = step!(senv, nothing)
+        @test r1 == r2
+    end
+
+    @testset "Reproducibility" begin
+        # Same wrapper, repeated reset_to_initial!: identical episodes
+        senv = SeededEnvironment(SeededMockEnv(; max_steps=8); seed=123)
+        ep1 = run_episode!(senv)
+        ep2 = run_episode!(senv)
+        @test ep1 == ep2
+        @test length(ep1) == 8
+
+        # Different seeds give different episodes
+        senvA = SeededEnvironment(SeededMockEnv(; max_steps=8); seed=1)
+        senvB = SeededEnvironment(SeededMockEnv(; max_steps=8); seed=2)
+        @test run_episode!(senvA) != run_episode!(senvB)
+
+        # reset_to_initial! on an unseeded wrapper does not error and resets the env
+        senvU = SeededEnvironment(SeededMockEnv())
+        reset_to_initial!(senvU)
+        @test senvU.env.step == 0
+    end
+end

--- a/test/environment.jl
+++ b/test/environment.jl
@@ -1,20 +1,20 @@
 const DFLUtils = DecisionFocusedLearningBenchmarks.Utils
 
-mutable struct SeededMockEnv <: DFLUtils.AbstractEnvironment
+mutable struct MockEnv <: DFLUtils.AbstractEnvironment
     max_steps::Int
     step::Int
     state::Float64
 end
-SeededMockEnv(; max_steps::Int=5) = SeededMockEnv(max_steps, 0, 0.0)
+MockEnv(; max_steps::Int=5) = MockEnv(max_steps, 0, 0.0)
 
-DFLUtils.is_terminated(e::SeededMockEnv) = e.step >= e.max_steps
-DFLUtils.observe(e::SeededMockEnv) = ([e.state], e.step)
-function DFLUtils.reset!(e::SeededMockEnv, rng::AbstractRNG)
+DFLUtils.is_terminated(e::MockEnv) = e.step >= e.max_steps
+DFLUtils.observe(e::MockEnv) = ([e.state], e.step)
+function DFLUtils.reset!(e::MockEnv, rng::AbstractRNG)
     e.step = 0
     e.state = rand(rng)
     return nothing
 end
-function DFLUtils.step!(e::SeededMockEnv, action, rng::AbstractRNG)
+function DFLUtils.step!(e::MockEnv, action, rng::AbstractRNG)
     e.step += 1
     r = rand(rng)
     e.state += r
@@ -32,7 +32,7 @@ end
 
 @testset "SeededEnvironment" begin
     @testset "Construction and accessors" begin
-        e = SeededMockEnv()
+        e = MockEnv()
         senv = SeededEnvironment(e; seed=42)
         @test senv isa AbstractEnvironment
         @test senv.env === e
@@ -41,20 +41,20 @@ end
         @test occursin("seed=", sprint(show, senv))
 
         # Integer seeds are accepted and stored as UInt
-        @test get_seed(SeededEnvironment(SeededMockEnv(); seed=7)) === UInt(7)
-        @test get_seed(SeededEnvironment(SeededMockEnv(); seed=UInt(7))) === UInt(7)
+        @test get_seed(SeededEnvironment(MockEnv(); seed=7)) === UInt(7)
+        @test get_seed(SeededEnvironment(MockEnv(); seed=UInt(7))) === UInt(7)
 
         # Unseeded wrapper
-        @test get_seed(SeededEnvironment(SeededMockEnv())) === nothing
+        @test get_seed(SeededEnvironment(MockEnv())) === nothing
 
         # Explicit rng is used as-is
         myrng = Xoshiro(123)
-        senv2 = SeededEnvironment(SeededMockEnv(); seed=1, rng=myrng)
+        senv2 = SeededEnvironment(MockEnv(); seed=1, rng=myrng)
         @test DFLUtils.get_rng(senv2) === myrng
     end
 
     @testset "Delegation to wrapped env" begin
-        senv = SeededEnvironment(SeededMockEnv(; max_steps=3); seed=0)
+        senv = SeededEnvironment(MockEnv(; max_steps=3); seed=0)
         reset_to_initial!(senv)
         @test is_terminated(senv) == is_terminated(senv.env)
         @test observe(senv) == observe(senv.env)
@@ -70,7 +70,7 @@ end
 
     @testset "reset! variants" begin
         # Integer seed: re-seeds the wrapper rng to that seed, then resets
-        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        senv = SeededEnvironment(MockEnv(); seed=0)
         reset!(senv, 7)
         s7a = senv.env.state
         reset!(senv, 7)
@@ -83,13 +83,13 @@ end
         @test senv.env.step == 0
 
         # rng argument: resets using the provided rng, not the wrapper's
-        e = SeededMockEnv()
+        e = MockEnv()
         senv = SeededEnvironment(e; seed=0)
         reset!(senv, Xoshiro(99))
         @test e.state == rand(Xoshiro(99))
 
         # no-arg reset!: uses the wrapper's current rng state (advances, does not re-seed)
-        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        senv = SeededEnvironment(MockEnv(); seed=0)
         reset_to_initial!(senv)
         s1 = senv.env.state
         reset!(senv)
@@ -97,7 +97,7 @@ end
         @test s1 != s2
 
         # reset!(env, nothing) is equivalent to reset!(env) (no re-seeding)
-        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        senv = SeededEnvironment(MockEnv(); seed=0)
         Random.seed!(DFLUtils.get_rng(senv), 123)
         reset!(senv, nothing)
         sa = senv.env.state
@@ -109,14 +109,14 @@ end
 
     @testset "step! variants" begin
         # step! with explicit rng uses that rng
-        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        senv = SeededEnvironment(MockEnv(); seed=0)
         reset!(senv, 0)
         r = step!(senv, nothing, Xoshiro(5))
         @test r == rand(Xoshiro(5))
         @test senv.env.step == 1
 
         # step! without rng uses the wrapper rng (reproducible from the same seed)
-        senv = SeededEnvironment(SeededMockEnv(); seed=0)
+        senv = SeededEnvironment(MockEnv(); seed=0)
         reset_to_initial!(senv)
         r1 = step!(senv, nothing)
         reset_to_initial!(senv)
@@ -126,19 +126,19 @@ end
 
     @testset "Reproducibility" begin
         # Same wrapper, repeated reset_to_initial!: identical episodes
-        senv = SeededEnvironment(SeededMockEnv(; max_steps=8); seed=123)
+        senv = SeededEnvironment(MockEnv(; max_steps=8); seed=123)
         ep1 = run_episode!(senv)
         ep2 = run_episode!(senv)
         @test ep1 == ep2
         @test length(ep1) == 8
 
         # Different seeds give different episodes
-        senvA = SeededEnvironment(SeededMockEnv(; max_steps=8); seed=1)
-        senvB = SeededEnvironment(SeededMockEnv(; max_steps=8); seed=2)
+        senvA = SeededEnvironment(MockEnv(; max_steps=8); seed=1)
+        senvB = SeededEnvironment(MockEnv(; max_steps=8); seed=2)
         @test run_episode!(senvA) != run_episode!(senvB)
 
         # reset_to_initial! on an unseeded wrapper does not error and resets the env
-        senvU = SeededEnvironment(SeededMockEnv())
+        senvU = SeededEnvironment(MockEnv())
         reset_to_initial!(senvU)
         @test senvU.env.step == 0
     end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -5,7 +5,7 @@ using Test
 @testset "AbstractBenchmark interface" begin
     struct DummyBenchmark <: AbstractStaticBenchmark end
     b = DummyBenchmark()
-    rng = MersenneTwister(1234)
+    rng = Xoshiro(1234)
     @test_throws ErrorException generate_instance(b, rng)
     @test_throws ErrorException generate_maximizer(b)
     @test_throws ErrorException generate_statistical_model(b; seed=0)

--- a/test/maintenance.jl
+++ b/test/maintenance.jl
@@ -35,13 +35,13 @@ end
 
 @testset "Maintenance - Instance Generation" begin
     b = MaintenanceBenchmark(; N=10, K=3, n=5, p=0.3, c_f=5.0, c_m=3.0, max_steps=50)
-    rng = MersenneTwister(42)
+    rng = Xoshiro(42)
 
     instance = maintenance.Instance(b, rng)
 
     # test state is randomly initialized
     state1 = maintenance.starting_state(instance)
-    rng2 = MersenneTwister(43)
+    rng2 = Xoshiro(43)
     instance2 = maintenance.Instance(b, rng2)
     state2 = maintenance.starting_state(instance2)
     @test state1 != state2
@@ -62,13 +62,12 @@ end
 
 @testset "Maintenance - Environment Initialization" begin
     b = MaintenanceBenchmark()
-    instance = maintenance.Instance(b, MersenneTwister(42))
+    instance = maintenance.Instance(b, Xoshiro(42))
 
-    env = maintenance.Environment(instance; seed=123)
+    env = maintenance.Environment(instance)
 
     # Test initial state
     @test env.step == 1
-    @test env.seed == 123
     @test !is_terminated(env)
 
     # Test accessor functions
@@ -83,14 +82,14 @@ end
 
 @testset "Maintenance - Environment Reset" begin
     b = MaintenanceBenchmark()
-    instance = maintenance.Instance(b, MersenneTwister(42))
-    env = maintenance.Environment(instance; seed=123)
+    instance = maintenance.Instance(b, Xoshiro(42))
+    env = maintenance.Environment(instance)
 
     # Modify environment state
     env.step = 3
 
     # Reset environment
-    reset!(env)
+    reset!(env, Xoshiro(123))
 
     # Check reset state
     @test env.step == 1
@@ -98,8 +97,8 @@ end
 
 @testset "Maintenance - Cost" begin
     b = MaintenanceBenchmark()
-    instance = maintenance.Instance(b, MersenneTwister(42))
-    env = maintenance.Environment(instance; seed=123)
+    instance = maintenance.Instance(b, Xoshiro(42))
+    env = maintenance.Environment(instance)
 
     env.degradation_state = [1, 1]
     @test maintenance.maintenance_cost(env, BitVector([false, false])) == 0.0
@@ -117,35 +116,36 @@ end
 
 @testset "Maintenance - Environment Step" begin
     b = MaintenanceBenchmark()
-    instance = maintenance.Instance(b, MersenneTwister(42))
-    env = maintenance.Environment(instance; seed=123)
+    instance = maintenance.Instance(b, Xoshiro(42))
+    env = maintenance.Environment(instance)
 
     maintenance_vect = BitVector([false, false])
+    rng = Xoshiro(123)
 
     initial_step = env.step
     # Take a step
-    reward = step!(env, maintenance_vect)
+    reward = step!(env, maintenance_vect, rng)
 
     # Check step progression
     @test env.step == initial_step + 1
-    @test reward ≥ 0.0  # Reward should be non-negative 
+    @test reward ≥ 0.0  # Reward should be non-negative
 
     # Test termination
     for _ in 1:(maintenance.max_steps(env) - 1)
         if !is_terminated(env)
-            step!(env, maintenance_vect)
+            step!(env, maintenance_vect, rng)
         end
     end
     @test is_terminated(env)
 
     # Test error on terminated environment
-    @test_throws AssertionError step!(env, maintenance_vect)
+    @test_throws AssertionError step!(env, maintenance_vect, rng)
 end
 
 @testset "Maintenance - Observation" begin
     b = MaintenanceBenchmark()
-    instance = maintenance.Instance(b, MersenneTwister(42))
-    env = maintenance.Environment(instance; seed=123)
+    instance = maintenance.Instance(b, Xoshiro(42))
+    env = maintenance.Environment(instance)
     env.degradation_state = [1, 1]
 
     state, features = observe(env)
@@ -181,9 +181,9 @@ end
 
     # Test policy output format
     env = environments[1]
-    reset!(env)
+    reset_to_initial!(env)
 
-    greedy_action = greedy(env)
+    greedy_action = greedy(env.env)
     @test greedy_action isa BitVector && length(greedy_action) == 2
 end
 
@@ -196,7 +196,7 @@ end
     maximizer = generate_maximizer(b)
 
     # Test integration with sample data
-    sample = generate_sample(b, MersenneTwister(42))
+    sample = generate_sample(b, Xoshiro(42))
     @test hasfield(typeof(sample), :context)
 
     environments = generate_environments(b, 3; seed=42)

--- a/test/maintenance.jl
+++ b/test/maintenance.jl
@@ -166,6 +166,10 @@ end
 
     # Generate test data
     environments = generate_environments(b, 10; seed=0)
+    @test environments isa Vector{<:SeededEnvironment}
+    single = generate_environment(b; seed=0)
+    @test single isa SeededEnvironment
+    @test get_seed(single) == get_seed(generate_environments(b, 1; seed=0)[1])
 
     # Get policies
     policies = generate_baseline_policies(b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Random
 
     include("utils.jl")
     include("interface.jl")
+    include("environment.jl")
 
     include("argmax.jl")
     include("argmax_2d.jl")


### PR DESCRIPTION
Introduce a `SeededEnvironment` wrapper that is put around all concrete environments by `generate_environments`.
Concrete environments now shouldn't manage their own seed or RNG, the AbstractEnv interface is updated accordingly: `reset!` and `step!` now require an `rng` argument, the default `get_seed` method was removed, and the default RNG is switched from `MersenneTwister` to `Xoshiro`.

- **`SeededEnvironment{E,R}`** (`src/Utils/environment/seeded_environment.jl`) wraps any `AbstractEnvironment` with a `seed` + `rng`.
- **`reset_to_initial!(env)`** re-seed to the stored seed and resets.
- **`rollout!(policy, env, rng)`** runs an episode from the current state, never resets. 
- `generate_environments` now returns `Vector{SeededEnvironment}`, seeding each env from an internal seed stream, same for `generate_environment`.
- Now the user only needs to define `build_environment` instead of the old `generate_environment`.
- **`evaluate_policy!(policy, env::SeededEnvironment; seed=nothing)`** resets to the initial seed (or a `seed` override) then rolls out.
- All dynamic benchmarks (DVS, Maintenance, Assortment) were migrated to the new interface.
