### PR TITLE
build: remove UnicodePlots and TestItemRunner from test dependencies

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,8 +13,6 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
-UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [sources]


### PR DESCRIPTION
PRs #91 and #90 can be closed after this is merged