### PR TITLE
feat!: Implement AbstractPolicy type hierarchy

### DIFF
--- a/src/ContextualStochasticArgmax/ContextualStochasticArgmax.jl
+++ b/src/ContextualStochasticArgmax/ContextualStochasticArgmax.jl
@@ -126,7 +126,7 @@ Each policy has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
 """
 function Utils.generate_baseline_policies(::ContextualStochasticArgmaxBenchmark)
     return (;
-        saa=Policy{ContextualStochasticArgmaxBenchmark}(
+        saa=ScenarioPolicy{ContextualStochasticArgmaxBenchmark}(
             "SAA", "argmax of mean scenarios", csa_saa_policy
         ),
     )

--- a/src/ContextualStochasticArgmax/ContextualStochasticArgmax.jl
+++ b/src/ContextualStochasticArgmax/ContextualStochasticArgmax.jl
@@ -125,7 +125,11 @@ Return the named baseline policies for [`ContextualStochasticArgmaxBenchmark`](@
 Each policy has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
 """
 function Utils.generate_baseline_policies(::ContextualStochasticArgmaxBenchmark)
-    return (; saa=Policy("SAA", "argmax of mean scenarios", csa_saa_policy))
+    return (;
+        saa=Policy{ContextualStochasticArgmaxBenchmark}(
+            "SAA", "argmax of mean scenarios", csa_saa_policy
+        ),
+    )
 end
 
 """

--- a/src/ContextualStochasticArgmax/ContextualStochasticArgmax.jl
+++ b/src/ContextualStochasticArgmax/ContextualStochasticArgmax.jl
@@ -126,7 +126,7 @@ Each policy has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
 """
 function Utils.generate_baseline_policies(::ContextualStochasticArgmaxBenchmark)
     return (;
-        saa=ScenarioPolicy{ContextualStochasticArgmaxBenchmark}(
+        saa=Policy{ContextualStochasticArgmaxBenchmark}(
             "SAA", "argmax of mean scenarios", csa_saa_policy
         ),
     )

--- a/src/DecisionFocusedLearningBenchmarks.jl
+++ b/src/DecisionFocusedLearningBenchmarks.jl
@@ -71,7 +71,7 @@ export get_seed, is_terminated, observe, reset!, reset_to_initial!, step!
 
 export Policy, ScenarioPolicy, evaluate_policy!, rollout_step!
 export AbstractPolicy,
-    AbstractDynamicPolicy,
+    DynamicPolicy,
     AbstractStaticPolicy,
     AbstractScenarioPolicy,
     AbstractStepPolicy,

--- a/src/DecisionFocusedLearningBenchmarks.jl
+++ b/src/DecisionFocusedLearningBenchmarks.jl
@@ -69,8 +69,13 @@ export ExogenousStochasticBenchmark,
 export AbstractEnvironment, SeededEnvironment
 export get_seed, is_terminated, observe, reset!, reset_to_initial!, step!
 
-export Policy, evaluate_policy!, rollout!, single_rollout!
-export AbstractPolicy, AbstractRolloutPolicy, AbstractFullHorizonPolicy
+export Policy, ScenarioPolicy, evaluate_policy!, rollout_step!
+export AbstractPolicy,
+    AbstractDynamicPolicy,
+    AbstractStaticPolicy,
+    AbstractScenarioPolicy,
+    AbstractStepPolicy,
+    AbstractTrajectoryPolicy
 
 export generate_instance,
     generate_sample,

--- a/src/DecisionFocusedLearningBenchmarks.jl
+++ b/src/DecisionFocusedLearningBenchmarks.jl
@@ -69,11 +69,11 @@ export ExogenousStochasticBenchmark,
 export AbstractEnvironment, SeededEnvironment
 export get_seed, is_terminated, observe, reset!, reset_to_initial!, step!
 
-export Policy, ScenarioPolicy, evaluate_policy!, rollout_step!
+export Policy, evaluate_policy!, rollout_step!
 export AbstractPolicy,
     DynamicPolicy,
-    AbstractStaticPolicy,
-    AbstractScenarioPolicy,
+    StaticPolicy,
+    StochasticPolicy,
     AbstractStepPolicy,
     AbstractTrajectoryPolicy
 

--- a/src/DecisionFocusedLearningBenchmarks.jl
+++ b/src/DecisionFocusedLearningBenchmarks.jl
@@ -69,7 +69,8 @@ export ExogenousStochasticBenchmark,
 export AbstractEnvironment, SeededEnvironment
 export get_seed, is_terminated, observe, reset!, reset_to_initial!, step!
 
-export Policy, evaluate_policy!
+export Policy, evaluate_policy!, rollout!, single_rollout!
+export AbstractPolicy, AbstractRolloutPolicy, AbstractFullHorizonPolicy
 
 export generate_instance,
     generate_sample,

--- a/src/DynamicAssortment/DynamicAssortment.jl
+++ b/src/DynamicAssortment/DynamicAssortment.jl
@@ -115,12 +115,12 @@ Returns two policies for the dynamic assortment benchmark:
 - `Expert`: selects the assortment with the highest expected revenue (through brute-force enumeration)
 """
 function Utils.generate_baseline_policies(::DynamicAssortmentBenchmark)
-    greedy = Policy(
+    greedy = Policy{DynamicAssortmentBenchmark}(
         "Greedy",
         "policy that selects the assortment with items with the highest prices",
         greedy_policy,
     )
-    expert = Policy(
+    expert = Policy{DynamicAssortmentBenchmark}(
         "Expert",
         "policy that selects the assortment with the highest expected revenue",
         expert_policy,

--- a/src/DynamicVehicleScheduling/DynamicVehicleScheduling.jl
+++ b/src/DynamicVehicleScheduling/DynamicVehicleScheduling.jl
@@ -124,12 +124,12 @@ Returns a tuple containing:
 - `greedy`: A policy that dispatches vehicles to the nearest customer
 """
 function Utils.generate_baseline_policies(::DynamicVehicleSchedulingBenchmark)
-    lazy = Policy(
+    lazy = Policy{DynamicVehicleSchedulingBenchmark}(
         "Lazy",
         "Lazy policy that dispatches vehicles only when they are ready.",
         lazy_policy,
     )
-    greedy = Policy(
+    greedy = Policy{DynamicVehicleSchedulingBenchmark}(
         "Greedy",
         "Greedy policy that dispatches vehicles to the nearest customer.",
         greedy_policy,

--- a/src/DynamicVehicleScheduling/policy.jl
+++ b/src/DynamicVehicleScheduling/policy.jl
@@ -42,8 +42,8 @@ Full-horizon anticipative policy for the dynamic vehicle scheduling benchmark.
 It solves the anticipative VSP over the whole episode
 via [`anticipative_solver`](@ref).
 """
-struct AnticipativeSolverPolicy <:
-       Utils.AbstractFullHorizonPolicy{DynamicVehicleSchedulingBenchmark} end
+struct AnticipativePolicy <:
+       Utils.AbstractTrajectoryPolicy{DynamicVehicleSchedulingBenchmark} end
 
 """
 $TYPEDSIGNATURES
@@ -54,6 +54,6 @@ The environment is assumed to already be at the state it should be solved from:
 resetting is handled upstream by [`evaluate_policy!`](@ref),
 so this always calls [`anticipative_solver`](@ref) with `reset_env=false`.
 """
-function (::AnticipativeSolverPolicy)(env::DVSPEnv, rng::AbstractRNG; kwargs...)
+function (::AnticipativePolicy)(env::DVSPEnv, rng::AbstractRNG; kwargs...)
     return anticipative_solver(env, rng; reset_env=false, kwargs...)
 end

--- a/src/DynamicVehicleScheduling/policy.jl
+++ b/src/DynamicVehicleScheduling/policy.jl
@@ -34,3 +34,26 @@ function (π::KleopatraVSPPolicy)(env::DVSPEnv; model_builder=highs_model)
     routes = prize_collecting_vsp(θ; instance=state, model_builder)
     return routes
 end
+
+"""
+$TYPEDEF
+
+Full-horizon anticipative policy for the dynamic vehicle scheduling benchmark. 
+It solves the anticipative VSP over the whole episode
+via [`anticipative_solver`](@ref).
+"""
+struct AnticipativeSolverPolicy <:
+       Utils.AbstractFullHorizonPolicy{DynamicVehicleSchedulingBenchmark} end
+
+"""
+$TYPEDSIGNATURES
+
+Solve the whole episode at once via [`anticipative_solver`](@ref) and return
+`(total_reward, dataset)`. 
+The environment is assumed to already be at the state it should be solved from: 
+resetting is handled upstream by [`evaluate_policy!`](@ref),
+so this always calls [`anticipative_solver`](@ref) with `reset_env=false`.
+"""
+function (::AnticipativeSolverPolicy)(env::DVSPEnv, rng::AbstractRNG; kwargs...)
+    return anticipative_solver(env, rng; reset_env=false, kwargs...)
+end

--- a/src/Maintenance/Maintenance.jl
+++ b/src/Maintenance/Maintenance.jl
@@ -128,7 +128,7 @@ Returns a policy for the maintenance benchmark:
 - `Greedy`: maintains components when they are in the last state before failure, up to the maintenance capacity
 """
 function Utils.generate_baseline_policies(::MaintenanceBenchmark)
-    greedy = Policy(
+    greedy = Policy{MaintenanceBenchmark}(
         "Greedy",
         "policy that maintains components when they are in the last state before failure, up to the maintenance capacity",
         greedy_policy,

--- a/src/StochasticVehicleScheduling/policies.jl
+++ b/src/StochasticVehicleScheduling/policies.jl
@@ -86,16 +86,18 @@ Each policy has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
 """
 function svs_generate_baseline_policies(::StochasticVehicleSchedulingBenchmark)
     return (;
-        deterministic=Policy(
+        deterministic=Policy{StochasticVehicleSchedulingBenchmark}(
             "Deterministic MIP", "Ignores delays", svs_deterministic_policy
         ),
-        saa=Policy("SAA (col gen)", "Stochastic MIP over K scenarios", svs_saa_policy),
-        saa_mip=Policy(
+        saa=Policy{StochasticVehicleSchedulingBenchmark}(
+            "SAA (col gen)", "Stochastic MIP over K scenarios", svs_saa_policy
+        ),
+        saa_mip=Policy{StochasticVehicleSchedulingBenchmark}(
             "SAA (exact MIP)",
             "Exact stochastic MIP over K scenarios via compact linearized formulation",
             svs_saa_mip_policy,
         ),
-        local_search=Policy(
+        local_search=Policy{StochasticVehicleSchedulingBenchmark}(
             "Local search", "Heuristic with K scenarios", svs_local_search_policy
         ),
     )

--- a/src/StochasticVehicleScheduling/policies.jl
+++ b/src/StochasticVehicleScheduling/policies.jl
@@ -86,18 +86,18 @@ Each policy has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
 """
 function svs_generate_baseline_policies(::StochasticVehicleSchedulingBenchmark)
     return (;
-        deterministic=Policy{StochasticVehicleSchedulingBenchmark}(
+        deterministic=ScenarioPolicy{StochasticVehicleSchedulingBenchmark}(
             "Deterministic MIP", "Ignores delays", svs_deterministic_policy
         ),
-        saa=Policy{StochasticVehicleSchedulingBenchmark}(
+        saa=ScenarioPolicy{StochasticVehicleSchedulingBenchmark}(
             "SAA (col gen)", "Stochastic MIP over K scenarios", svs_saa_policy
         ),
-        saa_mip=Policy{StochasticVehicleSchedulingBenchmark}(
+        saa_mip=ScenarioPolicy{StochasticVehicleSchedulingBenchmark}(
             "SAA (exact MIP)",
             "Exact stochastic MIP over K scenarios via compact linearized formulation",
             svs_saa_mip_policy,
         ),
-        local_search=Policy{StochasticVehicleSchedulingBenchmark}(
+        local_search=ScenarioPolicy{StochasticVehicleSchedulingBenchmark}(
             "Local search", "Heuristic with K scenarios", svs_local_search_policy
         ),
     )

--- a/src/StochasticVehicleScheduling/policies.jl
+++ b/src/StochasticVehicleScheduling/policies.jl
@@ -86,18 +86,18 @@ Each policy has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
 """
 function svs_generate_baseline_policies(::StochasticVehicleSchedulingBenchmark)
     return (;
-        deterministic=ScenarioPolicy{StochasticVehicleSchedulingBenchmark}(
+        deterministic=Policy{StochasticVehicleSchedulingBenchmark}(
             "Deterministic MIP", "Ignores delays", svs_deterministic_policy
         ),
-        saa=ScenarioPolicy{StochasticVehicleSchedulingBenchmark}(
+        saa=Policy{StochasticVehicleSchedulingBenchmark}(
             "SAA (col gen)", "Stochastic MIP over K scenarios", svs_saa_policy
         ),
-        saa_mip=ScenarioPolicy{StochasticVehicleSchedulingBenchmark}(
+        saa_mip=Policy{StochasticVehicleSchedulingBenchmark}(
             "SAA (exact MIP)",
             "Exact stochastic MIP over K scenarios via compact linearized formulation",
             svs_saa_mip_policy,
         ),
-        local_search=ScenarioPolicy{StochasticVehicleSchedulingBenchmark}(
+        local_search=Policy{StochasticVehicleSchedulingBenchmark}(
             "Local search", "Heuristic with K scenarios", svs_local_search_policy
         ),
     )

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -16,17 +16,22 @@ include("maximizers.jl")
 include("environment/abstract_environment.jl")
 include("environment/seeded_environment.jl")
 include("interface/abstract_benchmark.jl")
-include("policy.jl")
 include("interface/static_benchmark.jl")
 include("interface/stochastic_benchmark.jl")
 include("interface/dynamic_benchmark.jl")
+include("policy.jl")
 include("grid_graph.jl")
 include("misc.jl")
 include("model_builders.jl")
 
-export DataSample, Policy
-export AbstractPolicy, AbstractRolloutPolicy, AbstractFullHorizonPolicy
-export evaluate_policy!, rollout!, single_rollout!
+export DataSample, Policy, ScenarioPolicy
+export AbstractPolicy,
+    AbstractDynamicPolicy,
+    AbstractStaticPolicy,
+    AbstractScenarioPolicy,
+    AbstractStepPolicy,
+    AbstractTrajectoryPolicy
+export evaluate_policy!, rollout!, rollout_step!
 export TopKMaximizer, one_hot_argmax
 
 export AbstractEnvironment, SeededEnvironment

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -15,8 +15,8 @@ include("data_sample.jl")
 include("maximizers.jl")
 include("environment/abstract_environment.jl")
 include("environment/seeded_environment.jl")
-include("policy.jl")
 include("interface/abstract_benchmark.jl")
+include("policy.jl")
 include("interface/static_benchmark.jl")
 include("interface/stochastic_benchmark.jl")
 include("interface/dynamic_benchmark.jl")
@@ -25,7 +25,8 @@ include("misc.jl")
 include("model_builders.jl")
 
 export DataSample, Policy
-export evaluate_policy!
+export AbstractPolicy, AbstractRolloutPolicy, AbstractFullHorizonPolicy
+export evaluate_policy!, rollout!, single_rollout!
 export TopKMaximizer, one_hot_argmax
 
 export AbstractEnvironment, SeededEnvironment

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -24,14 +24,14 @@ include("grid_graph.jl")
 include("misc.jl")
 include("model_builders.jl")
 
-export DataSample, Policy, ScenarioPolicy
+export DataSample, Policy
 export AbstractPolicy,
     DynamicPolicy,
-    AbstractStaticPolicy,
-    AbstractScenarioPolicy,
+    StaticPolicy,
+    StochasticPolicy,
     AbstractStepPolicy,
     AbstractTrajectoryPolicy
-export evaluate_policy!, rollout!, rollout_step!
+export evaluate_policy!, rollout_step!
 export TopKMaximizer, one_hot_argmax
 
 export AbstractEnvironment, SeededEnvironment

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -26,7 +26,7 @@ include("model_builders.jl")
 
 export DataSample, Policy, ScenarioPolicy
 export AbstractPolicy,
-    AbstractDynamicPolicy,
+    DynamicPolicy,
     AbstractStaticPolicy,
     AbstractScenarioPolicy,
     AbstractStepPolicy,

--- a/src/Utils/policy.jl
+++ b/src/Utils/policy.jl
@@ -13,12 +13,15 @@ concrete flavors.
 abstract type AbstractPolicy{B<:AbstractBenchmark} end
 
 """
-$TYPEDEF
+    DynamicPolicy
 
-Abstract type for policies associated to dynamic benchmarks.
-Pre-implemented subtypes are [`AbstractStepPolicy`](@ref) and [`AbstractTrajectoryPolicy`](@ref).
+Type alias matching any [`AbstractPolicy`](@ref) built for a dynamic benchmark, i.e.
+`AbstractPolicy{<:AbstractDynamicBenchmark}`. Use this to dispatch on any policy for a
+dynamic benchmark.
+The subtypes [`AbstractStepPolicy`](@ref) and [`AbstractTrajectoryPolicy`](@ref)
+are DynamicPolicies.
 """
-abstract type AbstractDynamicPolicy{B<:AbstractDynamicBenchmark} <: AbstractPolicy{B} end
+const DynamicPolicy = AbstractPolicy{<:AbstractDynamicBenchmark}
 
 """
 $TYPEDEF
@@ -48,7 +51,7 @@ Specialize [`rollout_step!`](@ref) on `AbstractStepPolicy{B}` for a given benchm
 `B` to customize what gets recorded in each step's [`DataSample`](@ref) (e.g. extra
 `context` or `extra` fields), without reimplementing the rollout loop.
 """
-abstract type AbstractStepPolicy{B} <: AbstractDynamicPolicy{B} end
+abstract type AbstractStepPolicy{B<:AbstractDynamicBenchmark} <: AbstractPolicy{B} end
 
 """
 $TYPEDEF
@@ -61,7 +64,7 @@ A subtype `P <: AbstractTrajectoryPolicy` must be callable as
 where `dataset` is a `Vector{<:DataSample}`. [`rollout!`](@ref) dispatches straight to
 this call instead of stepping through [`rollout_step!`](@ref).
 """
-abstract type AbstractTrajectoryPolicy{B} <: AbstractDynamicPolicy{B} end
+abstract type AbstractTrajectoryPolicy{B<:AbstractDynamicBenchmark} <: AbstractPolicy{B} end
 
 """
 $TYPEDEF

--- a/src/Utils/policy.jl
+++ b/src/Utils/policy.jl
@@ -109,6 +109,7 @@ function Base.show(io::IO, p::Policy)
     println(io, "$(p.name): $(p.description)")
     return nothing
 end
+
 """
 $TYPEDSIGNATURES
 

--- a/src/Utils/policy.jl
+++ b/src/Utils/policy.jl
@@ -1,15 +1,68 @@
 """
 $TYPEDEF
 
-Policy type for decision-focused learning benchmarks.
+Abstract supertype for all policies acting on benchmark `B`. A policy is anything
+callable that produces decisions; the `B` type parameter ties it to the benchmark it was
+built for, which lets [`single_rollout!`](@ref) and [`rollout!`](@ref) be specialized per
+benchmark by dispatching on the policy's type rather than on a separate benchmark
+argument.
+
+See [`AbstractRolloutPolicy`](@ref) and [`AbstractFullHorizonPolicy`](@ref) for the two
+concrete flavors.
 """
-struct Policy{P}
+abstract type AbstractPolicy{B<:AbstractBenchmark} end
+
+"""
+$TYPEDEF
+
+Abstract supertype for policies that decide one step at a time. Such a policy is called
+once per environment step (as `policy(env; kwargs...) -> y`), via
+[`single_rollout!`](@ref), which [`rollout!`](@ref) loops until the environment
+terminates.
+
+Specialize [`single_rollout!`](@ref) on `AbstractRolloutPolicy{B}` for a given benchmark
+`B` to customize what gets recorded in each step's [`DataSample`](@ref) (e.g. extra
+`context` or `extra` fields), without reimplementing the rollout loop.
+"""
+abstract type AbstractRolloutPolicy{B} <: AbstractPolicy{B} end
+
+"""
+$TYPEDEF
+
+Abstract supertype for policies that decide the entire episode at once instead of one
+step at a time (e.g. an anticipative/offline solver that plans over the full horizon).
+
+A subtype `P <: AbstractFullHorizonPolicy` must be callable as
+`(policy::P)(env::AbstractEnvironment, rng::AbstractRNG; kwargs...) -> (total_reward, dataset)`,
+where `dataset` is a `Vector{<:DataSample}`. [`rollout!`](@ref) dispatches straight to
+this call instead of stepping through [`single_rollout!`](@ref).
+"""
+abstract type AbstractFullHorizonPolicy{B} <: AbstractPolicy{B} end
+
+"""
+$TYPEDEF
+
+Policy type for decision-focused learning benchmarks, tagged with the benchmark type `B`
+it was built for (e.g. `Policy{MyBenchmark}("name", "description", f)`). Wrapping a
+callable in `Policy{B}` makes it an [`AbstractRolloutPolicy`](@ref)`{B}`, which enables
+per-benchmark specialization of [`single_rollout!`](@ref).
+"""
+struct Policy{B,P} <: AbstractRolloutPolicy{B}
     "policy name"
     name::String
     "policy description"
     description::String
     "policy run function"
     policy::P
+end
+
+"""
+$TYPEDSIGNATURES
+
+Construct a `Policy{B}` tagged for benchmark type `B`, e.g. `Policy{MyBenchmark}("Greedy", "...", greedy_policy)`.
+"""
+function Policy{B}(name::String, description::String, policy::P) where {B,P}
+    return Policy{B,P}(name, description, policy)
 end
 
 function Base.show(io::IO, p::Policy)
@@ -28,28 +81,61 @@ end
 """
 $TYPEDSIGNATURES
 
+Perform a single step of a rollout: query `policy` for a decision on the current state of
+`env`, record the pre-step features/state, apply the decision with `step!`, and package
+the result into a [`DataSample`](@ref) with `extra=(; reward)`.
+
+This is the extension point for customizing what a rollout records: add a method
+specialized on `policy::AbstractRolloutPolicy{B}` for a given benchmark `B` to add extra
+`context` or `extra` fields, without having to reimplement [`rollout!`](@ref) itself.
+"""
+function single_rollout!(
+    policy::AbstractRolloutPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
+)
+    y = policy(env; kwargs...)
+    features, state = observe(env)
+    state_copy = deepcopy(state)
+    reward = step!(env, y, rng)
+    return DataSample(; x=features, y=y, instance=state_copy, extra=(; reward))
+end
+
+"""
+$TYPEDSIGNATURES
+
 Run the policy from the environment's current state (without resetting), using `rng`
 for per-step randomness. Returns the total reward and a dataset of observations.
+
+Each step delegates to [`single_rollout!`](@ref); specialize that function instead of
+this one to customize what gets recorded per step.
 """
-function rollout!(policy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...)
+function rollout!(
+    policy::AbstractRolloutPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
+)
     total_reward = 0.0
     labeled_dataset = DataSample[]
-    step = 0
     while !is_terminated(env)
-        step += 1
-        y = policy(env; kwargs...)
-        features, state = observe(env)
-        state_copy = deepcopy(state)
-        reward = step!(env, y, rng)
-        sample = DataSample(; x=features, y=y, instance=state_copy, extra=(; reward, step))
+        sample = single_rollout!(policy, env, rng; kwargs...)
         if isempty(labeled_dataset)
             labeled_dataset = typeof(sample)[sample]
         else
             push!(labeled_dataset, sample)
         end
-        total_reward += reward
+        total_reward += sample.reward
     end
     return total_reward, labeled_dataset
+end
+
+"""
+$TYPEDSIGNATURES
+
+Run a full-horizon policy: delegate directly to `policy(env, rng; kwargs...)`, which must
+return `(total_reward, dataset)` for the whole episode in one call, instead of looping
+step by step through [`single_rollout!`](@ref).
+"""
+function rollout!(
+    policy::AbstractFullHorizonPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
+)
+    return policy(env, rng; kwargs...)
 end
 
 """

--- a/src/Utils/policy.jl
+++ b/src/Utils/policy.jl
@@ -3,11 +3,11 @@ $TYPEDEF
 
 Abstract supertype for all policies acting on benchmark `B`. A policy is anything
 callable that produces decisions; the `B` type parameter ties it to the benchmark it was
-built for, which lets [`single_rollout!`](@ref) and [`rollout!`](@ref) be specialized per
+built for, which lets [`rollout_step!`](@ref) and [`rollout!`](@ref) be specialized per
 benchmark by dispatching on the policy's type rather than on a separate benchmark
 argument.
 
-See [`AbstractRolloutPolicy`](@ref) and [`AbstractFullHorizonPolicy`](@ref) for the two
+See [`AbstractStepPolicy`](@ref) and [`AbstractTrajectoryPolicy`](@ref) for the two
 concrete flavors.
 """
 abstract type AbstractPolicy{B<:AbstractBenchmark} end
@@ -15,16 +15,40 @@ abstract type AbstractPolicy{B<:AbstractBenchmark} end
 """
 $TYPEDEF
 
+Abstract type for policies associated to dynamic benchmarks.
+Pre-implemented subtypes are [`AbstractStepPolicy`](@ref) and [`AbstractTrajectoryPolicy`](@ref).
+"""
+abstract type AbstractDynamicPolicy{B<:AbstractDynamicBenchmark} <: AbstractPolicy{B} end
+
+"""
+$TYPEDEF
+
+Abstract type for policies associated to static benchmarks.
+"""
+abstract type AbstractStaticPolicy{B<:AbstractStaticBenchmark} <: AbstractPolicy{B} end
+
+"""
+$TYPEDEF
+
+Abstract type for stochastic policies that take scenarios as input, e.g. a callable with
+signature `(ctx_sample, scenarios) -> Vector{DataSample}`. See [`ScenarioPolicy`](@ref)
+for the wrapper type.
+"""
+abstract type AbstractScenarioPolicy{B<:AbstractStochasticBenchmark} <: AbstractPolicy{B} end
+
+"""
+$TYPEDEF
+
 Abstract supertype for policies that decide one step at a time. Such a policy is called
 once per environment step (as `policy(env; kwargs...) -> y`), via
-[`single_rollout!`](@ref), which [`rollout!`](@ref) loops until the environment
+[`rollout_step!`](@ref), which [`rollout!`](@ref) loops until the environment
 terminates.
 
-Specialize [`single_rollout!`](@ref) on `AbstractRolloutPolicy{B}` for a given benchmark
+Specialize [`rollout_step!`](@ref) on `AbstractStepPolicy{B}` for a given benchmark
 `B` to customize what gets recorded in each step's [`DataSample`](@ref) (e.g. extra
 `context` or `extra` fields), without reimplementing the rollout loop.
 """
-abstract type AbstractRolloutPolicy{B} <: AbstractPolicy{B} end
+abstract type AbstractStepPolicy{B} <: AbstractDynamicPolicy{B} end
 
 """
 $TYPEDEF
@@ -32,22 +56,22 @@ $TYPEDEF
 Abstract supertype for policies that decide the entire episode at once instead of one
 step at a time (e.g. an anticipative/offline solver that plans over the full horizon).
 
-A subtype `P <: AbstractFullHorizonPolicy` must be callable as
+A subtype `P <: AbstractTrajectoryPolicy` must be callable as
 `(policy::P)(env::AbstractEnvironment, rng::AbstractRNG; kwargs...) -> (total_reward, dataset)`,
 where `dataset` is a `Vector{<:DataSample}`. [`rollout!`](@ref) dispatches straight to
-this call instead of stepping through [`single_rollout!`](@ref).
+this call instead of stepping through [`rollout_step!`](@ref).
 """
-abstract type AbstractFullHorizonPolicy{B} <: AbstractPolicy{B} end
+abstract type AbstractTrajectoryPolicy{B} <: AbstractDynamicPolicy{B} end
 
 """
 $TYPEDEF
 
 Policy type for decision-focused learning benchmarks, tagged with the benchmark type `B`
 it was built for (e.g. `Policy{MyBenchmark}("name", "description", f)`). Wrapping a
-callable in `Policy{B}` makes it an [`AbstractRolloutPolicy`](@ref)`{B}`, which enables
-per-benchmark specialization of [`single_rollout!`](@ref).
+callable in `Policy{B}` makes it an [`AbstractStepPolicy`](@ref)`{B}`, which enables
+per-benchmark specialization of [`rollout_step!`](@ref).
 """
-struct Policy{B,P} <: AbstractRolloutPolicy{B}
+struct Policy{B,P} <: AbstractStepPolicy{B}
     "policy name"
     name::String
     "policy description"
@@ -65,6 +89,12 @@ function Policy{B}(name::String, description::String, policy::P) where {B,P}
     return Policy{B,P}(name, description, policy)
 end
 
+function Policy(
+    b::B, name::String, description::String, policy::P
+) where {B<:AbstractDynamicBenchmark,P}
+    return Policy{B,P}(name, description, policy)
+end
+
 function Base.show(io::IO, p::Policy)
     println(io, "$(p.name): $(p.description)")
     return nothing
@@ -79,6 +109,50 @@ function (p::Policy)(args...; kwargs...)
 end
 
 """
+$TYPEDEF
+
+Policy wrapper for stochastic (scenario-based) benchmarks, tagged with the benchmark type
+`B` it was built for (e.g. `ScenarioPolicy{MyBenchmark}("name", "description", f)`). The
+wrapped callable typically has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
+
+Use [`Policy`](@ref) instead for dynamic (environment-stepping) policies: the two are
+kept separate because they wrap fundamentally different calling conventions and neither
+plugs into the other's rollout machinery.
+"""
+struct ScenarioPolicy{B,P} <: AbstractScenarioPolicy{B}
+    "policy name"
+    name::String
+    "policy description"
+    description::String
+    "policy run function"
+    policy::P
+end
+
+"""
+$TYPEDSIGNATURES
+
+Construct a `ScenarioPolicy{B}` tagged for benchmark type `B`, e.g.
+`ScenarioPolicy{MyBenchmark}("SAA", "...", saa_policy)`.
+"""
+function ScenarioPolicy{B}(name::String, description::String, policy::P) where {B,P}
+    return ScenarioPolicy{B,P}(name, description, policy)
+end
+
+function Base.show(io::IO, p::ScenarioPolicy)
+    println(io, "$(p.name): $(p.description)")
+    return nothing
+end
+
+"""
+$TYPEDSIGNATURES
+
+Run the policy on the given context sample and scenarios.
+"""
+function (p::ScenarioPolicy)(args...; kwargs...)
+    return p.policy(args...; kwargs...)
+end
+
+"""
 $TYPEDSIGNATURES
 
 Perform a single step of a rollout: query `policy` for a decision on the current state of
@@ -86,11 +160,11 @@ Perform a single step of a rollout: query `policy` for a decision on the current
 the result into a [`DataSample`](@ref) with `extra=(; reward)`.
 
 This is the extension point for customizing what a rollout records: add a method
-specialized on `policy::AbstractRolloutPolicy{B}` for a given benchmark `B` to add extra
+specialized on `policy::AbstractStepPolicy{B}` for a given benchmark `B` to add extra
 `context` or `extra` fields, without having to reimplement [`rollout!`](@ref) itself.
 """
-function single_rollout!(
-    policy::AbstractRolloutPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
+function rollout_step!(
+    policy::AbstractStepPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
 )
     y = policy(env; kwargs...)
     features, state = observe(env)
@@ -105,16 +179,16 @@ $TYPEDSIGNATURES
 Run the policy from the environment's current state (without resetting), using `rng`
 for per-step randomness. Returns the total reward and a dataset of observations.
 
-Each step delegates to [`single_rollout!`](@ref); specialize that function instead of
+Each step delegates to [`rollout_step!`](@ref); specialize that function instead of
 this one to customize what gets recorded per step.
 """
 function rollout!(
-    policy::AbstractRolloutPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
+    policy::AbstractStepPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
 )
     total_reward = 0.0
     labeled_dataset = DataSample[]
     while !is_terminated(env)
-        sample = single_rollout!(policy, env, rng; kwargs...)
+        sample = rollout_step!(policy, env, rng; kwargs...)
         if isempty(labeled_dataset)
             labeled_dataset = typeof(sample)[sample]
         else
@@ -130,10 +204,10 @@ $TYPEDSIGNATURES
 
 Run a full-horizon policy: delegate directly to `policy(env, rng; kwargs...)`, which must
 return `(total_reward, dataset)` for the whole episode in one call, instead of looping
-step by step through [`single_rollout!`](@ref).
+step by step through [`rollout_step!`](@ref).
 """
 function rollout!(
-    policy::AbstractFullHorizonPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
+    policy::AbstractTrajectoryPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
 )
     return policy(env, rng; kwargs...)
 end

--- a/src/Utils/policy.jl
+++ b/src/Utils/policy.jl
@@ -109,7 +109,7 @@ function Base.show(io::IO, p::Policy)
     println(io, "$(p.name): $(p.description)")
     return nothing
 end
-"""scen
+"""
 $TYPEDSIGNATURES
 
 Run the policy and get the next decision on the given environment/instance.

--- a/src/Utils/policy.jl
+++ b/src/Utils/policy.jl
@@ -111,13 +111,10 @@ end
 """
 $TYPEDEF
 
-Policy wrapper for stochastic (scenario-based) benchmarks, tagged with the benchmark type
-`B` it was built for (e.g. `ScenarioPolicy{MyBenchmark}("name", "description", f)`). The
+Policy wrapper for stochastic benchmarks with policies taking scenarios as input. The
 wrapped callable typically has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
 
-Use [`Policy`](@ref) instead for dynamic (environment-stepping) policies: the two are
-kept separate because they wrap fundamentally different calling conventions and neither
-plugs into the other's rollout machinery.
+Use [`Policy`](@ref) instead for dynamic (environment-stepping) policies.
 """
 struct ScenarioPolicy{B,P} <: AbstractScenarioPolicy{B}
     "policy name"

--- a/src/Utils/policy.jl
+++ b/src/Utils/policy.jl
@@ -7,8 +7,9 @@ built for, which lets [`rollout_step!`](@ref) and [`rollout!`](@ref) be speciali
 benchmark by dispatching on the policy's type rather than on a separate benchmark
 argument.
 
-See [`AbstractStepPolicy`](@ref) and [`AbstractTrajectoryPolicy`](@ref) for the two
-concrete flavors.
+The generic wrapper [`Policy`](@ref) covers most cases; see [`AbstractStepPolicy`](@ref)
+and [`AbstractTrajectoryPolicy`](@ref) for custom policy types that decide one step at a
+time or plan a whole episode at once.
 """
 abstract type AbstractPolicy{B<:AbstractBenchmark} end
 
@@ -17,27 +18,27 @@ abstract type AbstractPolicy{B<:AbstractBenchmark} end
 
 Type alias matching any [`AbstractPolicy`](@ref) built for a dynamic benchmark, i.e.
 `AbstractPolicy{<:AbstractDynamicBenchmark}`. Use this to dispatch on any policy for a
-dynamic benchmark.
-The subtypes [`AbstractStepPolicy`](@ref) and [`AbstractTrajectoryPolicy`](@ref)
-are DynamicPolicies.
+dynamic benchmark. Such a policy is stepped through the environment by
+[`rollout!`](@ref), unless it is an [`AbstractTrajectoryPolicy`](@ref).
 """
 const DynamicPolicy = AbstractPolicy{<:AbstractDynamicBenchmark}
 
 """
-$TYPEDEF
+    StaticPolicy
 
-Abstract type for policies associated to static benchmarks.
+Type alias matching any [`AbstractPolicy`](@ref) built for a static benchmark, i.e.
+`AbstractPolicy{<:AbstractStaticBenchmark}`.
 """
-abstract type AbstractStaticPolicy{B<:AbstractStaticBenchmark} <: AbstractPolicy{B} end
+const StaticPolicy = AbstractPolicy{<:AbstractStaticBenchmark}
 
 """
-$TYPEDEF
+    StochasticPolicy
 
-Abstract type for stochastic policies that take scenarios as input, e.g. a callable with
-signature `(ctx_sample, scenarios) -> Vector{DataSample}`. See [`ScenarioPolicy`](@ref)
-for the wrapper type.
+Type alias matching any [`AbstractPolicy`](@ref) built for a stochastic benchmark, i.e.
+`AbstractPolicy{<:AbstractStochasticBenchmark}`. Such policies take scenarios as input,
+e.g. a callable with signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
 """
-abstract type AbstractScenarioPolicy{B<:AbstractStochasticBenchmark} <: AbstractPolicy{B} end
+const StochasticPolicy = AbstractPolicy{<:AbstractStochasticBenchmark}
 
 """
 $TYPEDEF
@@ -45,11 +46,9 @@ $TYPEDEF
 Abstract supertype for policies that decide one step at a time. Such a policy is called
 once per environment step (as `policy(env; kwargs...) -> y`), via
 [`rollout_step!`](@ref), which [`rollout!`](@ref) loops until the environment
-terminates.
-
-Specialize [`rollout_step!`](@ref) on `AbstractStepPolicy{B}` for a given benchmark
-`B` to customize what gets recorded in each step's [`DataSample`](@ref) (e.g. extra
-`context` or `extra` fields), without reimplementing the rollout loop.
+terminates. This is the default behavior for any [`DynamicPolicy`](@ref) (including the
+generic [`Policy`](@ref) wrapper); subtype `AbstractStepPolicy` to state it explicitly
+for a custom policy type.
 """
 abstract type AbstractStepPolicy{B<:AbstractDynamicBenchmark} <: AbstractPolicy{B} end
 
@@ -69,12 +68,15 @@ abstract type AbstractTrajectoryPolicy{B<:AbstractDynamicBenchmark} <: AbstractP
 """
 $TYPEDEF
 
-Policy type for decision-focused learning benchmarks, tagged with the benchmark type `B`
-it was built for (e.g. `Policy{MyBenchmark}("name", "description", f)`). Wrapping a
-callable in `Policy{B}` makes it an [`AbstractStepPolicy`](@ref)`{B}`, which enables
-per-benchmark specialization of [`rollout_step!`](@ref).
+Policy wrapper for decision-focused learning benchmarks, tagged with the benchmark type
+`B` it was built for (e.g. `Policy{MyBenchmark}("name", "description", f)`). The wrapped
+callable's signature depends on the benchmark flavor: `(env; kwargs...) -> y` for a
+dynamic benchmark, `(ctx_sample, scenarios) -> Vector{DataSample}` for a stochastic one.
+
+Wrapping a callable in `Policy{B}` makes it an [`AbstractPolicy`](@ref)`{B}`, which
+enables per-benchmark specialization of [`rollout_step!`](@ref).
 """
-struct Policy{B,P} <: AbstractStepPolicy{B}
+struct Policy{B,P} <: AbstractPolicy{B}
     "policy name"
     name::String
     "policy description"
@@ -92,9 +94,14 @@ function Policy{B}(name::String, description::String, policy::P) where {B,P}
     return Policy{B,P}(name, description, policy)
 end
 
+"""
+$TYPEDSIGNATURES
+
+Construct a `Policy` tagged for the type of the given benchmark instance.
+"""
 function Policy(
-    b::B, name::String, description::String, policy::P
-) where {B<:AbstractDynamicBenchmark,P}
+    ::B, name::String, description::String, policy::P
+) where {B<:AbstractBenchmark,P}
     return Policy{B,P}(name, description, policy)
 end
 
@@ -102,7 +109,7 @@ function Base.show(io::IO, p::Policy)
     println(io, "$(p.name): $(p.description)")
     return nothing
 end
-"""
+"""scen
 $TYPEDSIGNATURES
 
 Run the policy and get the next decision on the given environment/instance.
@@ -112,65 +119,24 @@ function (p::Policy)(args...; kwargs...)
 end
 
 """
-$TYPEDEF
-
-Policy wrapper for stochastic benchmarks with policies taking scenarios as input. The
-wrapped callable typically has signature `(ctx_sample, scenarios) -> Vector{DataSample}`.
-
-Use [`Policy`](@ref) instead for dynamic (environment-stepping) policies.
-"""
-struct ScenarioPolicy{B,P} <: AbstractScenarioPolicy{B}
-    "policy name"
-    name::String
-    "policy description"
-    description::String
-    "policy run function"
-    policy::P
-end
-
-"""
-$TYPEDSIGNATURES
-
-Construct a `ScenarioPolicy{B}` tagged for benchmark type `B`, e.g.
-`ScenarioPolicy{MyBenchmark}("SAA", "...", saa_policy)`.
-"""
-function ScenarioPolicy{B}(name::String, description::String, policy::P) where {B,P}
-    return ScenarioPolicy{B,P}(name, description, policy)
-end
-
-function Base.show(io::IO, p::ScenarioPolicy)
-    println(io, "$(p.name): $(p.description)")
-    return nothing
-end
-
-"""
-$TYPEDSIGNATURES
-
-Run the policy on the given context sample and scenarios.
-"""
-function (p::ScenarioPolicy)(args...; kwargs...)
-    return p.policy(args...; kwargs...)
-end
-
-"""
 $TYPEDSIGNATURES
 
 Perform a single step of a rollout: query `policy` for a decision on the current state of
-`env`, record the pre-step features/state, apply the decision with `step!`, and package
-the result into a [`DataSample`](@ref) with `extra=(; reward)`.
+`env`, record the pre-step features/state, apply the decision with `step!`, record the reward
+and return the couple (reward, sample), where sample is a [`DataSample`](@ref).
 
 This is the extension point for customizing what a rollout records: add a method
-specialized on `policy::AbstractStepPolicy{B}` for a given benchmark `B` to add extra
+specialized on `policy::AbstractPolicy{B}` for a given benchmark `B` to add extra
 `context` or `extra` fields, without having to reimplement [`rollout!`](@ref) itself.
 """
 function rollout_step!(
-    policy::AbstractStepPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
+    policy::DynamicPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
 )
     y = policy(env; kwargs...)
     features, state = observe(env)
     state_copy = deepcopy(state)
     reward = step!(env, y, rng)
-    return DataSample(; x=features, y=y, instance=state_copy, extra=(; reward))
+    return reward, DataSample(; x=features, y=y, instance=state_copy, extra=(; reward))
 end
 
 """
@@ -183,18 +149,18 @@ Each step delegates to [`rollout_step!`](@ref); specialize that function instead
 this one to customize what gets recorded per step.
 """
 function rollout!(
-    policy::AbstractStepPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
+    policy::DynamicPolicy, env::AbstractEnvironment, rng::AbstractRNG; kwargs...
 )
     total_reward = 0.0
     labeled_dataset = DataSample[]
     while !is_terminated(env)
-        sample = rollout_step!(policy, env, rng; kwargs...)
+        reward, sample = rollout_step!(policy, env, rng; kwargs...)
         if isempty(labeled_dataset)
             labeled_dataset = typeof(sample)[sample]
         else
             push!(labeled_dataset, sample)
         end
-        total_reward += sample.reward
+        total_reward += reward
     end
     return total_reward, labeled_dataset
 end
@@ -221,7 +187,9 @@ running, which makes the rollout reproducible. Pass `seed` to override the wrapp
 stored seed for this evaluation. The wrapper's `rng` is the single source of
 randomness threaded into the underlying environment.
 """
-function evaluate_policy!(policy, env::SeededEnvironment; seed=nothing, kwargs...)
+function evaluate_policy!(
+    policy::DynamicPolicy, env::SeededEnvironment; seed=nothing, kwargs...
+)
     isnothing(seed) ? reset_to_initial!(env) : reset!(env, seed)
     return rollout!(policy, env.env, env.rng; kwargs...)
 end

--- a/test/dynamic_vsp.jl
+++ b/test/dynamic_vsp.jl
@@ -52,6 +52,26 @@
     @test isapprox(cost, cost2; atol=1e-5)
 end
 
+@testset "DVSP - AnticipativeSolverPolicy (full-horizon policy)" begin
+    using DecisionFocusedLearningBenchmarks.DynamicVehicleScheduling
+
+    b = DynamicVehicleSchedulingBenchmark(; two_dimensional_features=true)
+    env = generate_environment(b; seed=0)
+
+    policy = DynamicVehicleScheduling.AnticipativeSolverPolicy()
+    @test policy isa AbstractFullHorizonPolicy{DynamicVehicleSchedulingBenchmark}
+
+    r, dataset = evaluate_policy!(policy, env; nb_epochs=3)
+
+    # generate_anticipative_solver resets to the same initial seed by default, so it
+    # should reproduce the exact same trajectory as the full-horizon policy above.
+    trajectory = generate_anticipative_solver(b)(env; nb_epochs=3)
+
+    @test length(dataset) == length(trajectory) == 3
+    @test r ≈ sum(s.reward for s in trajectory)
+    @test all(d.y == t.y for (d, t) in zip(dataset, trajectory))
+end
+
 @testset "DVSP - generate_dataset with environments" begin
     using DecisionFocusedLearningBenchmarks.DynamicVehicleScheduling
 

--- a/test/dynamic_vsp.jl
+++ b/test/dynamic_vsp.jl
@@ -52,14 +52,14 @@
     @test isapprox(cost, cost2; atol=1e-5)
 end
 
-@testset "DVSP - AnticipativeSolverPolicy (full-horizon policy)" begin
+@testset "DVSP - AnticipativePolicy (full-horizon policy)" begin
     using DecisionFocusedLearningBenchmarks.DynamicVehicleScheduling
 
     b = DynamicVehicleSchedulingBenchmark(; two_dimensional_features=true)
     env = generate_environment(b; seed=0)
 
-    policy = DynamicVehicleScheduling.AnticipativeSolverPolicy()
-    @test policy isa AbstractFullHorizonPolicy{DynamicVehicleSchedulingBenchmark}
+    policy = DynamicVehicleScheduling.AnticipativePolicy()
+    @test policy isa AbstractTrajectoryPolicy{DynamicVehicleSchedulingBenchmark}
 
     r, dataset = evaluate_policy!(policy, env; nb_epochs=3)
 


### PR DESCRIPTION
This pull request addresses the issues raised in: https://github.com/JuliaDecisionFocusedLearning/DecisionFocusedLearningBenchmarks.jl/issues/93 and https://github.com/JuliaDecisionFocusedLearning/DecisionFocusedLearningBenchmarks.jl/issues/106

This PR introduces a new policy hierarchy based on an abstract `AbstractPolicy` type with two subtypes:

- `AbstractRolloutPolicy`: policies that produce a decision from the current state at each step of a rollout.
- `AbstractFullHorizonPolicy`: policies that, given an initial state and a planning horizon, compute the complete sequence of decisions in advance. This is particularly useful for anticipative or offline planning policies.

Benefits:
- More flexible rollouts. Each benchmark can now implement its own `single_rollout!` method, allowing users to choose which fields should be recorded in the resulting `DataSample`.
- Cleaner sample and dataset generation. For stochastic benchmarks, the function `generate_sample` currently has an unstable interface because it requires a `target_policy` that can be `nothing` while otherwise being expected to be callable with specific arguments. The new policy types makes it possible to refactor this API into a cleaner and more type-stable design.

Notes: To keep this PR focused and make the changes incremental, the existing `Policy` struct has been left unchanged. It could be revisited.